### PR TITLE
chore(deps): refine dependabot update rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    cooldown:
+      semver-major-days: 60
     groups:
       production-minor-and-patch:
         dependency-type: "production"
@@ -26,6 +28,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      major-updates:
-        update-types:
-          - "major"
+    ignore:
+      - dependency-name: "@types/node"


### PR DESCRIPTION
## Summary

Adjusts Dependabot so minor and patch updates stay grouped by dependency type, while major updates are reviewed individually after a cooldown period.

Ignores `@types/node` updates so Node typings stay aligned with the supported runtime version instead of the latest available release.