### PR TITLE
Chore/revise repo license & docs clarity

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,8 @@ This document covers local setup, day-to-day development, and architecture notes
 - Node.js `>=24.0.0`
 - pnpm via Corepack
 - Docker, when previewing container output locally
-- `mkcert`, when running HTTPS local development hosts
+- Local SSL certificates for HTTPS development hosts.
+  - This document includes setup guidance using `mkcert`, but the project only needs valid local certificate files at the expected paths.
 
 Check the top-level [`README.md`](./README.md) badges for the current repo-level Node engine and pnpm versions.
 
@@ -51,7 +52,7 @@ Add the relevant app host to your local hosts file:
 
 ### Local SSL
 
-Local wildcard certificates are shared repo-level infrastructure for apps running on `*.local.hoite.dev`.
+Local wildcard certificates are repo-level local development infrastructure for apps running on `*.local.hoite.dev`.
 
 The expected local certificate files are stored in:
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,26 @@
-# Creative Commons Attribution-NonCommercial 4.0 International License with Additional Permission Clause
+# PolyForm Noncommercial License 1.0.0 with Commercial Permission Notice
 
-This work is licensed under the [Creative Commons Attribution-NonCommercial 4.0 International License](http://creativecommons.org/licenses/by-nc/4.0/).
+Required Notice: Copyright © 2024-2026 Martin Høite
 
-## You are free to:
-- **Share** — copy and redistribute the material in any medium or format
-- **Adapt** — remix, transform, and build upon the material
+This software is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/).
 
-## Under the following terms:
-- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
-- **NonCommercial** — You may not use the material for commercial purposes without obtaining prior written permission from the author. To request permission, please contact me at [martin@hoite.dev](mailto:martin@hoite.dev).
+## Key terms
+
+- **NonCommercial** - You may only use the software for noncommercial purposes unless you have obtained prior written permission from the author.
+- **Notices** - You must include a copy of the license terms or a link to them, as well as the required notice above, with any copy of the software you distribute.
+- **No sublicensing** - You may not sublicense or transfer the license granted under these terms.
+- **No warranty** - The software is provided as is, without warranty or condition, and the author is not liable for damages arising from its use, as far as the law allows.
+
+## Commercial use
+
+Commercial use, including use in company work, client deliverables, paid products, internal business projects, or production systems, requires prior written permission from the author.
+
+To request permission, please contact [martin@hoite.dev](mailto:martin@hoite.dev).
+
+## Third-party software and dependencies
+
+This license applies only to the original Hoite Dev software, documentation, configuration, and other materials created by Martin Høite.
+
+Third-party software, dependencies, frameworks, libraries, tools, fonts, icons, assets, and other materials used by or referenced in this repository remain licensed under their respective licenses.
+
+Nothing in this license grants rights to third-party materials beyond the rights provided by their original licensors.

--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ Packages live under `packages/*` and provide shared code, styling, configuration
 
 ### `apps/site-nuxt`
 
-Nuxt SSR site app.
+Nuxt SSR site app, using Umbraco as the primary provider of content.
 
 ### `apps/frontend-docs`
 
-Frontend documentation app for the shared design system and app-specific component documentation.
+Frontend documentation app for the shared design system and app-specific components.
 
 Frontend docs are developed locally as separate Storybook workspaces. For deployment previews and production, they are built as one static output with the hub and composed Storybook refs served from the same app.
 
 ## Umbraco content layer
 
-The shared Umbraco content layer is maintained in a separate private repository.
+The shared Umbraco project is maintained in a separate private repository.
 
 This keeps the public monorepo focused on the frontend experience, shared design system, and documentation surfaces. This repository only contains the frontend-facing Umbraco integration and generated content helpers.
 
@@ -111,6 +111,6 @@ It helps accelerate exploration and iteration, while final decisions, validation
 
 ## License
 
-This project is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License with an Additional Permission Clause.
+This project is licensed under the PolyForm Noncommercial License 1.0.0. Commercial use requires prior written permission.
 
 See [LICENSE](./LICENSE.md).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "pnpm": ">=10.0.0",
     "node": ">=24.0.0"
   },
+  "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "build": "turbo build",
     "dev": "pnpm run dev:site:nuxt",


### PR DESCRIPTION
## Summary

Switches the repository license to the PolyForm Noncommercial License 1.0.0, replacing the previous Creative Commons-based license wording so the noncommercial usage terms are clearer and better aligned with the project.

Minor documentation wording and structure updates to improve clarity and consistency.