### PR TITLE
Feature/design system fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Packages live under `packages/*` and provide shared code, styling, configuration
 |  `- site-nuxt/                  # Site app built with Nuxt
 |- packages/
 |  |- biome-config/      # Shared Biome configuration
+|  |- diagnostics/       # Shared runtime diagnostics helpers
 |  |- ui/                # Shared styling foundation for the Hoite Dev design system
 |  |- ui-react/          # React component package for the Hoite Dev design system
 |  |- ui-vue/            # Vue component package for the Hoite Dev design system
@@ -85,6 +86,10 @@ Source-oriented Umbraco content package.
 
 Shared Biome configuration.
 
+### `packages/diagnostics`
+
+Shared runtime diagnostics helpers.
+
 ## Workspace docs
 
 ### Apps
@@ -101,6 +106,7 @@ Shared Biome configuration.
 - [packages/ui](./packages/ui/README.md)
 - [packages/ui-react](./packages/ui-react/README.md)
 - [packages/ui-vue](./packages/ui-vue/README.md)
+- [packages/diagnostics](./packages/diagnostics/README.md)
 - [packages/umbraco-client](./packages/umbraco-client/README.md)
 
 ## Use of AI

--- a/apps/frontend-docs/DOCS_CONSISTENCY_AGENT_NOTES.md
+++ b/apps/frontend-docs/DOCS_CONSISTENCY_AGENT_NOTES.md
@@ -1,0 +1,40 @@
+﻿# Frontend Docs Consistency Agent Notes
+
+Use this as a fast execution checklist when changing docs under `apps/frontend-docs`.
+
+## Routing
+
+- If contract meaning/copy changes: update shared docs metadata in `@hoite-dev/ui`.
+- If framework rendering changes: update React/Vue framework stories.
+- If docs page structure changes: update MDX and keep composition through shared docs helpers.
+- If hub contract display changes: update hub overview stories with shared hub templates.
+
+## Required Reuse
+
+- `shared/docs/FrameworkComponentDocsPage.tsx`
+- `shared/docs/DesignSystemDocsPage.tsx`
+- `shared/docs/DocsExample.tsx`
+- `shared/storybook/reactStoryLayouts.tsx`
+- `shared/storybook/vueStoryTemplates.ts`
+- `shared/storybook/hubContractTemplates.ts`
+- `shared/storybook/config.ts`
+
+## Consistency Rules
+
+- Keep React and Vue docs aligned on section order, control intent, and example intent.
+- Keep framework-specific source links present for each framework docs page.
+- Keep Storybook config through `createFrontendDocsStorybookConfig<StorybookConfig>(...)`.
+- Keep `@hoite-dev/ui/*.css` imports local to each Storybook app's `preview.ts`.
+
+## Validation
+
+Run relevant checks for touched apps:
+
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-react lint`
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-vue lint`
+- `pnpm --filter @hoite-dev/frontend-docs-hub lint`
+- `pnpm --filter @hoite-dev/frontend-docs-site-nuxt-components lint`
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-react typecheck`
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-vue typecheck`
+- `pnpm --filter @hoite-dev/frontend-docs-hub typecheck`
+- `pnpm --filter @hoite-dev/frontend-docs-site-nuxt-components typecheck`

--- a/apps/frontend-docs/DOCS_CONSISTENCY_README.md
+++ b/apps/frontend-docs/DOCS_CONSISTENCY_README.md
@@ -1,0 +1,104 @@
+﻿# Frontend Docs Consistency Guide
+
+Use this guide when you add or change docs in `apps/frontend-docs`.
+
+Covers:
+- `hub`
+- `design-system-react`
+- `design-system-vue`
+- `site-nuxt-components` (PoC scope)
+
+If you want the short execution checklist for automation or fast implementation passes, see `DOCS_CONSISTENCY_AGENT_NOTES.md`.
+
+## Start Here
+
+1. Identify the change type.
+2. Update the right source of truth.
+3. Reuse shared helpers before writing local wrappers.
+
+## Choose The Right Place
+
+- Contract meaning or docs copy changed:
+  - Update shared docs metadata in `@hoite-dev/ui` (for example `iconDocs`, `loadingDocs`, `typographyDocs`).
+- Framework rendering or behavior changed:
+  - Update framework stories (`*.stories.tsx` for React, `*.stories.ts` for Vue).
+- Public docs page composition changed:
+  - Update `*.docs.mdx`, but keep rendering through shared docs helpers.
+- Hub contract layout/table/chip presentation changed:
+  - Update hub overview stories using shared hub template helpers.
+
+## Reuse Before Rebuild
+
+Use these shared utilities first:
+
+- Public React/Vue docs page composition:
+  - `shared/docs/FrameworkComponentDocsPage.tsx`
+- Shared docs building blocks:
+  - `shared/docs/DesignSystemDocsPage.tsx`
+  - `shared/docs/DocsExample.tsx`
+- Story layout wrappers:
+  - React: `shared/storybook/reactStoryLayouts.tsx`
+  - Vue: `shared/storybook/vueStoryTemplates.ts`
+- Hub contract templates:
+  - `shared/storybook/hubContractTemplates.ts`
+- Storybook app config factory:
+  - `shared/storybook/config.ts`
+
+## React + Vue Docs Workflow
+
+1. Keep framework stories in their framework Storybook app.
+2. Keep shared docs metadata in `@hoite-dev/ui`.
+3. Compose docs pages with `FrameworkComponentDocsPage`.
+4. Keep React and Vue aligned on:
+   - section order
+   - control intent
+   - example intent
+   - source-link structure
+
+If React and Vue differ, document why in the story or docs description.
+
+## Hub Contract Workflow
+
+For `hub/src/stories/*Overview.stories.ts`, prefer:
+
+- `createContractPageTemplate`
+- `createContractSectionTemplate`
+- `createContractTableTemplate`
+- `createCodeChipListTemplate`
+- `createSubsectionTemplate`
+
+This keeps contract pages consistent and avoids copy-pasted table markup.
+
+## Storybook Setup Rules
+
+- In app `.storybook/main.ts`, use:
+  - `createFrontendDocsStorybookConfig<StorybookConfig>(...)`
+- Keep `@hoite-dev/ui/*.css` side-effect imports in each app's `preview.ts`.
+- Do not move those CSS imports into shared Storybook helper modules.
+
+## Controls Rules
+
+- Use `parameters.controls.sort = 'none'` when control order is intentional.
+- Use `tags: ['!dev']` for showcase-only stories when needed.
+- Keep live controls focused on meaningful component behavior.
+- Keep non-visual passthrough details in docs text or tables.
+
+## Done Checklist
+
+A docs change is complete when:
+
+1. Shared helpers were reused where applicable.
+2. React and Vue remain aligned in structure and intent.
+3. Source links are correct.
+4. Lint and typecheck pass for touched frontend-docs apps.
+
+Recommended checks:
+
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-react lint`
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-vue lint`
+- `pnpm --filter @hoite-dev/frontend-docs-hub lint`
+- `pnpm --filter @hoite-dev/frontend-docs-site-nuxt-components lint`
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-react typecheck`
+- `pnpm --filter @hoite-dev/frontend-docs-design-system-vue typecheck`
+- `pnpm --filter @hoite-dev/frontend-docs-hub typecheck`
+- `pnpm --filter @hoite-dev/frontend-docs-site-nuxt-components typecheck`

--- a/apps/frontend-docs/README.md
+++ b/apps/frontend-docs/README.md
@@ -17,6 +17,10 @@ Design-system docs pattern:
 - Shared copy and section structure can come from framework-agnostic metadata, so React and Vue pages read the same while still rendering their own stories.
 - Autodocs can be used for simple stories, but it is not the main pattern for shared public design-system docs.
 
+Consistency playbook:
+- `DOCS_CONSISTENCY_README.md`: human workflow and usage guide.
+- `DOCS_CONSISTENCY_AGENT_NOTES.md`: short execution checklist for automation-oriented edits.
+
 Expected long-term use:
 - Document app-specific components such as page sections, content blocks, and composed UI patterns.
 - Follow the same hub/ref pattern that can later be reused for other frontend apps, such as `site-react-components`.

--- a/apps/frontend-docs/README.md
+++ b/apps/frontend-docs/README.md
@@ -8,6 +8,7 @@ Scope:
 - `design-system-vue`: Vue implementation docs for the shared design system.
 - `site-nuxt-components`: integration PoC for app-specific component documentation from `apps/site-nuxt`.
 - `shared/docs`: cross-Storybook docs rendering helpers and source-link utilities for aligned React and Vue design-system docs pages.
+- `shared/storybook`: shared Storybook setup and template helpers used across frontend docs apps.
 
 `site-nuxt-components` is an integration PoC. It exists to prove that app-specific Storybooks can be built, referenced by the hub, and deployed alongside the design system docs.
 

--- a/apps/frontend-docs/design-system-react/.storybook/main.ts
+++ b/apps/frontend-docs/design-system-react/.storybook/main.ts
@@ -1,41 +1,21 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import type { StorybookConfig } from '@storybook/react-vite';
 import tailwindcss from '@tailwindcss/vite';
-import { mergeConfig } from 'vite';
 
 import {
-  createFrontendDocsViteOptions,
-  frontendDocsCoreConfig,
+  createFrontendDocsStorybookConfig,
   frontendDocsDefaultAddons,
   frontendDocsStoryGlobs,
 } from '../../shared/storybook/config.ts';
 
 const STORYBOOK_LOCAL_HOST = 'design-system-react.local.hoite.dev';
-const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const FRONTEND_DOCS_SHARED_ROOT = path.resolve(CURRENT_DIR, '../../shared');
 
-const config: StorybookConfig = {
-  addons: [...frontendDocsDefaultAddons],
-  framework: {
-    name: '@storybook/react-vite',
-    options: {},
-  },
-  core: frontendDocsCoreConfig,
+const config = createFrontendDocsStorybookConfig<StorybookConfig>({
+  addons: frontendDocsDefaultAddons,
+  frameworkName: '@storybook/react-vite',
+  host: STORYBOOK_LOCAL_HOST,
+  mainFileUrl: import.meta.url,
   stories: frontendDocsStoryGlobs,
-  async viteFinal(config) {
-    return mergeConfig(
-      config,
-      createFrontendDocsViteOptions({
-        aliases: {
-          '@frontend-docs-shared': FRONTEND_DOCS_SHARED_ROOT,
-        },
-        host: STORYBOOK_LOCAL_HOST,
-        plugins: [tailwindcss()],
-      }),
-    );
-  },
-};
+  vitePlugins: [tailwindcss()],
+});
 
 export default config;

--- a/apps/frontend-docs/design-system-react/src/stories/Icon.docs.mdx
+++ b/apps/frontend-docs/design-system-react/src/stories/Icon.docs.mdx
@@ -1,38 +1,19 @@
 import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { iconDocs } from '@hoite-dev/ui';
 
-import { DocsExample } from '@frontend-docs-shared/docs/DocsExample';
-import { DesignSystemDocsPage } from '@frontend-docs-shared/docs/DesignSystemDocsPage';
-import { createFrameworkSourceLinks } from '@frontend-docs-shared/docs/sourceLinks';
+import { FrameworkComponentDocsPage } from '@frontend-docs-shared/docs/FrameworkComponentDocsPage';
 import * as Stories from './Icon.stories';
 
 <Meta of={Stories} />
 
-<DesignSystemDocsPage
-  controls={<ArgTypes of={Stories.Playground} />}
+<FrameworkComponentDocsPage
+  argTypesBlock={ArgTypes}
+  canvasBlock={Canvas}
+  contractSourceLinks={iconDocs.sourceLinks}
+  controls={[{ story: Stories.Playground }]}
   docs={iconDocs}
-  examples={
-    <>
-      <DocsExample story={Stories.AllIcons}>
-        <Canvas of={Stories.AllIcons} />
-      </DocsExample>
-      <DocsExample story={Stories.Sizes}>
-        <Canvas of={Stories.Sizes} />
-      </DocsExample>
-      <DocsExample story={Stories.Rotations}>
-        <Canvas of={Stories.Rotations} />
-      </DocsExample>
-      <DocsExample story={Stories.Variants}>
-        <Canvas of={Stories.Variants} />
-      </DocsExample>
-    </>
-  }
-  sourceLinks={[
-    ...iconDocs.sourceLinks,
-    ...createFrameworkSourceLinks(
-      'React',
-      'packages/ui-react/src/components/primitives/static/Icon/Icon.tsx',
-      'apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx',
-    ),
-  ]}
+  examples={[Stories.AllIcons, Stories.Sizes, Stories.Rotations, Stories.Variants]}
+  framework="React"
+  implementationPath="packages/ui-react/src/components/primitives/static/Icon/Icon.tsx"
+  storiesPath="apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx"
 />

--- a/apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx
@@ -1,3 +1,4 @@
+import { StoryInfoPanel, StoryStack } from '@frontend-docs-shared/storybook/reactStoryLayouts';
 import {
   type IconName,
   type IconRotation,
@@ -95,8 +96,8 @@ function getShowcaseSurfaceClass(variant: IconVariant): string {
 
 function IconPlaygroundPreview(iconArgs: IconStoryArgs): ReactElement {
   return (
-    <div className='grid gap-4'>
-      <div className='rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4'>
+    <StoryStack>
+      <StoryInfoPanel>
         <p className='m-0 text-sm text-[var(--color-text-primary)]'>
           Use <code>name</code>, <code>size</code>, <code>rotation</code>, and <code>variant</code>{' '}
           as the main visual Icon API.
@@ -110,11 +111,11 @@ function IconPlaygroundPreview(iconArgs: IconStoryArgs): ReactElement {
           <code>role</code>, <code>aria-label</code>, and deliberate <code>data-*</code> attributes
           on the rendered SVG.
         </p>
-      </div>
+      </StoryInfoPanel>
       <div className={getSurfaceClass(iconArgs.variant)}>
         <Icon {...iconArgs} label='Playground icon' />
       </div>
-    </div>
+    </StoryStack>
   );
 }
 

--- a/apps/frontend-docs/design-system-react/src/stories/Loading.docs.mdx
+++ b/apps/frontend-docs/design-system-react/src/stories/Loading.docs.mdx
@@ -1,46 +1,27 @@
 import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { loadingDocs } from '@hoite-dev/ui';
 
-import { DocsExample } from '@frontend-docs-shared/docs/DocsExample';
-import { DesignSystemDocsPage } from '@frontend-docs-shared/docs/DesignSystemDocsPage';
-import { createFrameworkSourceLinks } from '@frontend-docs-shared/docs/sourceLinks';
+import { FrameworkComponentDocsPage } from '@frontend-docs-shared/docs/FrameworkComponentDocsPage';
 import * as Stories from './Loading.stories';
 
 <Meta of={Stories} />
 
-<DesignSystemDocsPage
-  controls={
-    <>
-      <h3>Loader</h3>
-      <ArgTypes of={Stories.LoaderPlayground} />
-      <h3>Progress</h3>
-      <ArgTypes of={Stories.ProgressPlayground}
-      />
-      <h3>CircularProgress</h3>
-      <ArgTypes of={Stories.CircularProgressPlayground}
-      />
-    </>
-  }
-  docs={loadingDocs}
-  examples={
-    <>
-      <DocsExample story={Stories.LoaderExamples}>
-        <Canvas of={Stories.LoaderExamples} />
-      </DocsExample>
-      <DocsExample story={Stories.ProgressExamples}>
-        <Canvas of={Stories.ProgressExamples} />
-      </DocsExample>
-      <DocsExample story={Stories.CircularProgressExamples}>
-        <Canvas of={Stories.CircularProgressExamples} />
-      </DocsExample>
-    </>
-  }
-  sourceLinks={[
-    ...loadingDocs.sourceLinks,
-    ...createFrameworkSourceLinks(
-      'React',
-      'packages/ui-react/src/components/primitives/static/Loading/index.ts',
-      'apps/frontend-docs/design-system-react/src/stories/Loading.stories.tsx',
-    ),
+<FrameworkComponentDocsPage
+  argTypesBlock={ArgTypes}
+  canvasBlock={Canvas}
+  contractSourceLinks={loadingDocs.sourceLinks}
+  controls={[
+    { title: 'Loader', story: Stories.LoaderPlayground },
+    { title: 'Progress', story: Stories.ProgressPlayground },
+    { title: 'CircularProgress', story: Stories.CircularProgressPlayground },
   ]}
+  docs={loadingDocs}
+  examples={[
+    Stories.LoaderExamples,
+    Stories.ProgressExamples,
+    Stories.CircularProgressExamples,
+  ]}
+  framework="React"
+  implementationPath="packages/ui-react/src/components/primitives/static/Loading/index.ts"
+  storiesPath="apps/frontend-docs/design-system-react/src/stories/Loading.stories.tsx"
 />

--- a/apps/frontend-docs/design-system-react/src/stories/Loading.docs.mdx
+++ b/apps/frontend-docs/design-system-react/src/stories/Loading.docs.mdx
@@ -11,12 +11,14 @@ import * as Stories from './Loading.stories';
 <DesignSystemDocsPage
   controls={
     <>
-      <h3>Loader Playground</h3>
+      <h3>Loader</h3>
       <ArgTypes of={Stories.LoaderPlayground} />
-      <h3>Progress Playground</h3>
-      <ArgTypes of={Stories.ProgressPlayground} />
-      <h3>CircularProgress Playground</h3>
-      <ArgTypes of={Stories.CircularProgressPlayground} />
+      <h3>Progress</h3>
+      <ArgTypes of={Stories.ProgressPlayground}
+      />
+      <h3>CircularProgress</h3>
+      <ArgTypes of={Stories.CircularProgressPlayground}
+      />
     </>
   }
   docs={loadingDocs}

--- a/apps/frontend-docs/design-system-react/src/stories/Loading.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Loading.stories.tsx
@@ -1,3 +1,4 @@
+import { StoryInfoPanel, StoryStack } from '@frontend-docs-shared/storybook/reactStoryLayouts';
 import {
   type LoadingColor,
   type LoadingSize,
@@ -173,14 +174,14 @@ export const LoaderPlayground: Story = {
     const ariaLabel = hasText(args.ariaLabel) ? args.ariaLabel : undefined;
 
     return (
-      <div className='grid gap-4'>
-        <div className='rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]'>
+      <StoryStack>
+        <StoryInfoPanel className='text-sm text-[var(--color-text-secondary)]'>
           Loader uses `aria-label` or `aria-labelledby` when it is not decorative.
-        </div>
+        </StoryInfoPanel>
         <div className={getSurfaceClass(args.color)}>
           <Loader aria-label={ariaLabel} color={args.color} size={args.size} />
         </div>
-      </div>
+      </StoryStack>
     );
   },
 };
@@ -199,11 +200,11 @@ export const ProgressPlayground: Story = {
     const value = args.indeterminate ? undefined : args.value;
 
     return (
-      <div className='grid gap-4'>
-        <div className='rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]'>
+      <StoryStack>
+        <StoryInfoPanel className='text-sm text-[var(--color-text-secondary)]'>
           Progress uses native <code>&lt;progress&gt;</code> semantics with shared numeric
           normalization.
-        </div>
+        </StoryInfoPanel>
         <div className={getSurfaceClass(args.color)}>
           <Progress
             aria-label={ariaLabel}
@@ -214,7 +215,7 @@ export const ProgressPlayground: Story = {
             value={value}
           />
         </div>
-      </div>
+      </StoryStack>
     );
   },
 };
@@ -244,10 +245,10 @@ export const CircularProgressPlayground: Story = {
     const label = hasText(args.label) ? args.label : undefined;
     const valueLabel = hasText(args.valueLabel) ? args.valueLabel : undefined;
     return (
-      <div className='grid gap-4'>
-        <div className='rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]'>
+      <StoryStack>
+        <StoryInfoPanel className='text-sm text-[var(--color-text-secondary)]'>
           CircularProgress supports centered value text as percentage or step fraction.
-        </div>
+        </StoryInfoPanel>
         <div className={getSurfaceClass(args.color)}>
           <CircularProgress
             aria-label={ariaLabel}
@@ -263,7 +264,7 @@ export const CircularProgressPlayground: Story = {
             valueLabel={valueLabel}
           />
         </div>
-      </div>
+      </StoryStack>
     );
   },
 };
@@ -313,7 +314,7 @@ export const ProgressExamples: Story = {
   },
   tags: ['!dev'],
   render: () => (
-    <div className='grid gap-4'>
+    <StoryStack>
       <div className='rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-surface)] p-5'>
         <Progress color='primary' label='Deploying assets' max={100} size='large' value={76} />
       </div>
@@ -323,7 +324,7 @@ export const ProgressExamples: Story = {
       <div className='rounded-xl bg-[var(--color-bg-brand)] p-5 text-[var(--color-text-on-fill)]'>
         <Progress color='on-fill' label='Publishing release' max={120} size='small' value={34} />
       </div>
-    </div>
+    </StoryStack>
   ),
 };
 

--- a/apps/frontend-docs/design-system-react/src/stories/Typography.docs.mdx
+++ b/apps/frontend-docs/design-system-react/src/stories/Typography.docs.mdx
@@ -1,27 +1,19 @@
 import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { typographyDocs } from '@hoite-dev/ui';
 
-import { DocsExample } from '@frontend-docs-shared/docs/DocsExample';
-import { DesignSystemDocsPage } from '@frontend-docs-shared/docs/DesignSystemDocsPage';
-import { createFrameworkSourceLinks } from '@frontend-docs-shared/docs/sourceLinks';
+import { FrameworkComponentDocsPage } from '@frontend-docs-shared/docs/FrameworkComponentDocsPage';
 import * as Stories from './Typography.stories';
 
 <Meta of={Stories} />
 
-<DesignSystemDocsPage
-  controls={<ArgTypes of={Stories.Playground} />}
+<FrameworkComponentDocsPage
+  argTypesBlock={ArgTypes}
+  canvasBlock={Canvas}
+  contractSourceLinks={typographyDocs.sourceLinks}
+  controls={[{ story: Stories.Playground }]}
   docs={typographyDocs}
-  examples={
-    <DocsExample story={Stories.Variants}>
-      <Canvas of={Stories.Variants} />
-    </DocsExample>
-  }
-  sourceLinks={[
-    ...typographyDocs.sourceLinks,
-    ...createFrameworkSourceLinks(
-      'React',
-      'packages/ui-react/src/components/primitives/static/Typography/Typography.tsx',
-      'apps/frontend-docs/design-system-react/src/stories/Typography.stories.tsx',
-    ),
-  ]}
+  examples={[Stories.Variants]}
+  framework="React"
+  implementationPath="packages/ui-react/src/components/primitives/static/Typography/Typography.tsx"
+  storiesPath="apps/frontend-docs/design-system-react/src/stories/Typography.stories.tsx"
 />

--- a/apps/frontend-docs/design-system-react/src/stories/Typography.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Typography.stories.tsx
@@ -1,3 +1,4 @@
+import { StoryInfoPanel, StoryStack } from '@frontend-docs-shared/storybook/reactStoryLayouts';
 import {
   resolveTypographyDefaultTag,
   supportedTypographyTags,
@@ -90,8 +91,8 @@ export const Playground: Story = {
     },
   },
   render: (args) => (
-    <div className='grid gap-4'>
-      <div className='rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4'>
+    <StoryStack>
+      <StoryInfoPanel>
         <p className='m-0 text-sm text-[var(--color-text-primary)]'>
           Use <code>variant</code>, <code>tag</code>, and text content as the main Typography API.
           Leave <code>tag</code> on the default option to use the selected variant&apos;s standard
@@ -102,11 +103,11 @@ export const Playground: Story = {
           <code>aria-label</code>, and deliberate <code>data-*</code> attributes on the rendered
           HTML element.
         </p>
-      </div>
+      </StoryInfoPanel>
       <Typography tag={normalizeTag(args.tag)} variant={args.variant}>
         {args.children}
       </Typography>
-    </div>
+    </StoryStack>
   ),
 };
 

--- a/apps/frontend-docs/design-system-vue/.storybook/main.ts
+++ b/apps/frontend-docs/design-system-vue/.storybook/main.ts
@@ -1,42 +1,22 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import type { StorybookConfig } from '@storybook/vue3-vite';
 import tailwindcss from '@tailwindcss/vite';
 import vue from '@vitejs/plugin-vue';
-import { mergeConfig } from 'vite';
 
 import {
-  createFrontendDocsViteOptions,
-  frontendDocsCoreConfig,
+  createFrontendDocsStorybookConfig,
   frontendDocsDefaultAddons,
   frontendDocsStoryGlobs,
 } from '../../shared/storybook/config.ts';
 
 const STORYBOOK_LOCAL_HOST = 'design-system-vue.local.hoite.dev';
-const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const FRONTEND_DOCS_SHARED_ROOT = path.resolve(CURRENT_DIR, '../../shared');
 
-const config: StorybookConfig = {
-  addons: [...frontendDocsDefaultAddons],
-  framework: {
-    name: '@storybook/vue3-vite',
-    options: {},
-  },
-  core: frontendDocsCoreConfig,
+const config = createFrontendDocsStorybookConfig<StorybookConfig>({
+  addons: frontendDocsDefaultAddons,
+  frameworkName: '@storybook/vue3-vite',
+  host: STORYBOOK_LOCAL_HOST,
+  mainFileUrl: import.meta.url,
   stories: frontendDocsStoryGlobs,
-  async viteFinal(config) {
-    return mergeConfig(
-      config,
-      createFrontendDocsViteOptions({
-        aliases: {
-          '@frontend-docs-shared': FRONTEND_DOCS_SHARED_ROOT,
-        },
-        host: STORYBOOK_LOCAL_HOST,
-        plugins: [tailwindcss(), vue()],
-      }),
-    );
-  },
-};
+  vitePlugins: [tailwindcss(), vue()],
+});
 
 export default config;

--- a/apps/frontend-docs/design-system-vue/src/stories/Icon.docs.mdx
+++ b/apps/frontend-docs/design-system-vue/src/stories/Icon.docs.mdx
@@ -1,38 +1,19 @@
 import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { iconDocs } from '@hoite-dev/ui';
 
-import { DocsExample } from '@frontend-docs-shared/docs/DocsExample';
-import { DesignSystemDocsPage } from '@frontend-docs-shared/docs/DesignSystemDocsPage';
-import { createFrameworkSourceLinks } from '@frontend-docs-shared/docs/sourceLinks';
+import { FrameworkComponentDocsPage } from '@frontend-docs-shared/docs/FrameworkComponentDocsPage';
 import * as Stories from './Icon.stories';
 
 <Meta of={Stories} />
 
-<DesignSystemDocsPage
-  controls={<ArgTypes of={Stories.Playground} />}
+<FrameworkComponentDocsPage
+  argTypesBlock={ArgTypes}
+  canvasBlock={Canvas}
+  contractSourceLinks={iconDocs.sourceLinks}
+  controls={[{ story: Stories.Playground }]}
   docs={iconDocs}
-  examples={
-    <>
-      <DocsExample story={Stories.AllIcons}>
-        <Canvas of={Stories.AllIcons} />
-      </DocsExample>
-      <DocsExample story={Stories.Sizes}>
-        <Canvas of={Stories.Sizes} />
-      </DocsExample>
-      <DocsExample story={Stories.Rotations}>
-        <Canvas of={Stories.Rotations} />
-      </DocsExample>
-      <DocsExample story={Stories.Variants}>
-        <Canvas of={Stories.Variants} />
-      </DocsExample>
-    </>
-  }
-  sourceLinks={[
-    ...iconDocs.sourceLinks,
-    ...createFrameworkSourceLinks(
-      'Vue',
-      'packages/ui-vue/src/components/primitives/static/Icon/Icon.vue',
-      'apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts',
-    ),
-  ]}
+  examples={[Stories.AllIcons, Stories.Sizes, Stories.Rotations, Stories.Variants]}
+  framework="Vue"
+  implementationPath="packages/ui-vue/src/components/primitives/static/Icon/Icon.vue"
+  storiesPath="apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts"
 />

--- a/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
@@ -1,3 +1,4 @@
+import { withStoryStack } from '@frontend-docs-shared/storybook/vueStoryTemplates';
 import {
   type IconName,
   type IconRotation,
@@ -105,8 +106,7 @@ const IconPlaygroundPreview = defineComponent({
       surfaceClass,
     };
   },
-  template: `
-    <div class="grid gap-4">
+  template: withStoryStack(`
       <div
         class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4"
       >
@@ -127,8 +127,7 @@ const IconPlaygroundPreview = defineComponent({
       <div :class="surfaceClass">
         <Icon v-bind="iconArgs" label="Playground icon" />
       </div>
-    </div>
-  `,
+  `),
 });
 
 const meta: Meta<IconStoryArgs> = {

--- a/apps/frontend-docs/design-system-vue/src/stories/Loading.docs.mdx
+++ b/apps/frontend-docs/design-system-vue/src/stories/Loading.docs.mdx
@@ -1,46 +1,27 @@
 import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { loadingDocs } from '@hoite-dev/ui';
 
-import { DocsExample } from '@frontend-docs-shared/docs/DocsExample';
-import { DesignSystemDocsPage } from '@frontend-docs-shared/docs/DesignSystemDocsPage';
-import { createFrameworkSourceLinks } from '@frontend-docs-shared/docs/sourceLinks';
+import { FrameworkComponentDocsPage } from '@frontend-docs-shared/docs/FrameworkComponentDocsPage';
 import * as Stories from './Loading.stories';
 
 <Meta of={Stories} />
 
-<DesignSystemDocsPage
-  controls={
-    <>
-      <h3>Loader</h3>
-      <ArgTypes of={Stories.LoaderPlayground} />
-      <h3>Progress</h3>
-      <ArgTypes of={Stories.ProgressPlayground}
-      />
-      <h3>CircularProgress</h3>
-      <ArgTypes of={Stories.CircularProgressPlayground}
-      />
-    </>
-  }
-  docs={loadingDocs}
-  examples={
-    <>
-      <DocsExample story={Stories.LoaderExamples}>
-        <Canvas of={Stories.LoaderExamples} />
-      </DocsExample>
-      <DocsExample story={Stories.ProgressExamples}>
-        <Canvas of={Stories.ProgressExamples} />
-      </DocsExample>
-      <DocsExample story={Stories.CircularProgressExamples}>
-        <Canvas of={Stories.CircularProgressExamples} />
-      </DocsExample>
-    </>
-  }
-  sourceLinks={[
-    ...loadingDocs.sourceLinks,
-    ...createFrameworkSourceLinks(
-      'Vue',
-      'packages/ui-vue/src/components/primitives/static/Loading/index.ts',
-      'apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts',
-    ),
+<FrameworkComponentDocsPage
+  argTypesBlock={ArgTypes}
+  canvasBlock={Canvas}
+  contractSourceLinks={loadingDocs.sourceLinks}
+  controls={[
+    { title: 'Loader', story: Stories.LoaderPlayground },
+    { title: 'Progress', story: Stories.ProgressPlayground },
+    { title: 'CircularProgress', story: Stories.CircularProgressPlayground },
   ]}
+  docs={loadingDocs}
+  examples={[
+    Stories.LoaderExamples,
+    Stories.ProgressExamples,
+    Stories.CircularProgressExamples,
+  ]}
+  framework="Vue"
+  implementationPath="packages/ui-vue/src/components/primitives/static/Loading/index.ts"
+  storiesPath="apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts"
 />

--- a/apps/frontend-docs/design-system-vue/src/stories/Loading.docs.mdx
+++ b/apps/frontend-docs/design-system-vue/src/stories/Loading.docs.mdx
@@ -11,12 +11,14 @@ import * as Stories from './Loading.stories';
 <DesignSystemDocsPage
   controls={
     <>
-      <h3>Loader Playground</h3>
+      <h3>Loader</h3>
       <ArgTypes of={Stories.LoaderPlayground} />
-      <h3>Progress Playground</h3>
-      <ArgTypes of={Stories.ProgressPlayground} />
-      <h3>CircularProgress Playground</h3>
-      <ArgTypes of={Stories.CircularProgressPlayground} />
+      <h3>Progress</h3>
+      <ArgTypes of={Stories.ProgressPlayground}
+      />
+      <h3>CircularProgress</h3>
+      <ArgTypes of={Stories.CircularProgressPlayground}
+      />
     </>
   }
   docs={loadingDocs}

--- a/apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts
@@ -1,3 +1,4 @@
+import { withStoryStack } from '@frontend-docs-shared/storybook/vueStoryTemplates';
 import {
   type LoadingColor,
   type LoadingSize,
@@ -148,16 +149,14 @@ const LoaderPlaygroundPreview = defineComponent({
       surfaceClass,
     };
   },
-  template: `
-    <div class="grid gap-4">
+  template: withStoryStack(`
       <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
         Loader uses <code>aria-label</code> or <code>aria-labelledby</code> when it is not decorative.
       </div>
       <div :class="surfaceClass">
         <Loader :aria-label="normalizedAriaLabel" :color="color" :size="size" />
       </div>
-    </div>
-  `,
+  `),
 });
 
 const ProgressPlaygroundPreview = defineComponent({
@@ -227,8 +226,7 @@ const ProgressPlaygroundPreview = defineComponent({
       surfaceClass,
     };
   },
-  template: `
-    <div class="grid gap-4">
+  template: withStoryStack(`
       <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
         Progress uses native <code>&lt;progress&gt;</code> semantics with shared numeric normalization.
       </div>
@@ -242,8 +240,7 @@ const ProgressPlaygroundPreview = defineComponent({
           :value="normalizedValue"
         />
       </div>
-    </div>
-  `,
+  `),
 });
 
 const CircularProgressPlaygroundPreview = defineComponent({
@@ -325,8 +322,7 @@ const CircularProgressPlaygroundPreview = defineComponent({
       surfaceClass,
     };
   },
-  template: `
-    <div class="grid gap-4">
+  template: withStoryStack(`
       <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
         CircularProgress supports centered value text as percentage or step fraction.
       </div>
@@ -345,8 +341,7 @@ const CircularProgressPlaygroundPreview = defineComponent({
           :value-label="normalizedValueLabel"
         />
       </div>
-    </div>
-  `,
+  `),
 });
 
 const meta: Meta<LoadingStoryArgs> = {
@@ -519,8 +514,7 @@ export const ProgressExamples: Story = {
   tags: ['!dev'],
   render: () => ({
     components: { Progress },
-    template: `
-      <div class="grid gap-4">
+    template: withStoryStack(`
         <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-surface)] p-5">
           <Progress color="primary" label="Deploying assets" :max="100" size="large" :value="76" />
         </div>
@@ -530,8 +524,7 @@ export const ProgressExamples: Story = {
         <div class="rounded-xl bg-[var(--color-bg-brand)] p-5 text-[var(--color-text-on-fill)]">
           <Progress color="on-fill" label="Publishing release" :max="120" size="small" :value="34" />
         </div>
-      </div>
-    `,
+    `),
   }),
 };
 

--- a/apps/frontend-docs/design-system-vue/src/stories/Typography.docs.mdx
+++ b/apps/frontend-docs/design-system-vue/src/stories/Typography.docs.mdx
@@ -1,27 +1,19 @@
 import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { typographyDocs } from '@hoite-dev/ui';
 
-import { DocsExample } from '@frontend-docs-shared/docs/DocsExample';
-import { DesignSystemDocsPage } from '@frontend-docs-shared/docs/DesignSystemDocsPage';
-import { createFrameworkSourceLinks } from '@frontend-docs-shared/docs/sourceLinks';
+import { FrameworkComponentDocsPage } from '@frontend-docs-shared/docs/FrameworkComponentDocsPage';
 import * as Stories from './Typography.stories';
 
 <Meta of={Stories} />
 
-<DesignSystemDocsPage
-  controls={<ArgTypes of={Stories.Playground} />}
+<FrameworkComponentDocsPage
+  argTypesBlock={ArgTypes}
+  canvasBlock={Canvas}
+  contractSourceLinks={typographyDocs.sourceLinks}
+  controls={[{ story: Stories.Playground }]}
   docs={typographyDocs}
-  examples={
-    <DocsExample story={Stories.Variants}>
-      <Canvas of={Stories.Variants} />
-    </DocsExample>
-  }
-  sourceLinks={[
-    ...typographyDocs.sourceLinks,
-    ...createFrameworkSourceLinks(
-      'Vue',
-      'packages/ui-vue/src/components/primitives/static/Typography/Typography.vue',
-      'apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts',
-    ),
-  ]}
+  examples={[Stories.Variants]}
+  framework="Vue"
+  implementationPath="packages/ui-vue/src/components/primitives/static/Typography/Typography.vue"
+  storiesPath="apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts"
 />

--- a/apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts
@@ -1,3 +1,4 @@
+import { withStoryStack } from '@frontend-docs-shared/storybook/vueStoryTemplates';
 import {
   supportedTypographyTags,
   type TypographyTag,
@@ -89,8 +90,7 @@ export const Playground: Story = {
         normalizedTag: computed(() => normalizeTag(args.tag)),
       };
     },
-    template: `
-      <div class="grid gap-4">
+    template: withStoryStack(`
         <div
           class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4"
         >
@@ -108,8 +108,7 @@ export const Playground: Story = {
         <Typography :tag="normalizedTag" :variant="args.variant">
           {{ args.children }}
         </Typography>
-      </div>
-    `,
+    `),
   }),
 };
 

--- a/apps/frontend-docs/hub/.storybook/main.ts
+++ b/apps/frontend-docs/hub/.storybook/main.ts
@@ -1,23 +1,16 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import type { StorybookConfig } from '@storybook/vue3-vite';
 import tailwindcss from '@tailwindcss/vite';
 import vue from '@vitejs/plugin-vue';
-import { mergeConfig } from 'vite';
 
 import {
-  createFrontendDocsViteOptions,
-  frontendDocsCoreConfig,
+  createFrontendDocsStorybookConfig,
   frontendDocsDefaultAddons,
   frontendDocsStoryGlobs,
 } from '../../shared/storybook/config.ts';
 
 const STORYBOOK_LOCAL_HOST = 'frontend-docs.local.hoite.dev';
-const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const FRONTEND_DOCS_SHARED_ROOT = path.resolve(CURRENT_DIR, '../../shared');
 
-const config: StorybookConfig = {
+const config = createFrontendDocsStorybookConfig<StorybookConfig>({
   addons: [
     ...frontendDocsDefaultAddons,
     {
@@ -27,11 +20,9 @@ const config: StorybookConfig = {
       },
     },
   ],
-  framework: {
-    name: '@storybook/vue3-vite',
-    options: {},
-  },
-  core: frontendDocsCoreConfig,
+  frameworkName: '@storybook/vue3-vite',
+  host: STORYBOOK_LOCAL_HOST,
+  mainFileUrl: import.meta.url,
   refs: () => {
     const reactStorybookUrl = process.env.STORYBOOK_REACT_REF_URL;
     const vueStorybookUrl = process.env.STORYBOOK_VUE_REF_URL;
@@ -65,18 +56,7 @@ const config: StorybookConfig = {
     };
   },
   stories: frontendDocsStoryGlobs,
-  async viteFinal(config) {
-    return mergeConfig(
-      config,
-      createFrontendDocsViteOptions({
-        aliases: {
-          '@frontend-docs-shared': FRONTEND_DOCS_SHARED_ROOT,
-        },
-        host: STORYBOOK_LOCAL_HOST,
-        plugins: [tailwindcss(), vue()],
-      }),
-    );
-  },
-};
+  vitePlugins: [tailwindcss(), vue()],
+});
 
 export default config;

--- a/apps/frontend-docs/hub/src/stories/IconOverview.stories.ts
+++ b/apps/frontend-docs/hub/src/stories/IconOverview.stories.ts
@@ -53,7 +53,7 @@ export const Overview: Story = {
       };
     },
     template: `
-      <div class="mx-auto w-full max-w-5xl px-4 py-6">
+      <div class="mx-auto max-w-5xl py-6">
         <div class="grid gap-6">
           <section class="grid gap-2">
             <h2 class="m-0 text-base font-semibold">Supported icon names</h2>

--- a/apps/frontend-docs/hub/src/stories/IconOverview.stories.ts
+++ b/apps/frontend-docs/hub/src/stories/IconOverview.stories.ts
@@ -1,4 +1,10 @@
 import {
+  createCodeChipListTemplate,
+  createContractPageTemplate,
+  createContractSectionTemplate,
+  createContractTableTemplate,
+} from '@frontend-docs-shared/storybook/hubContractTemplates';
+import {
   type IconRotation,
   type IconSize,
   type IconVariant,
@@ -52,115 +58,101 @@ export const Overview: Story = {
         variantRows,
       };
     },
-    template: `
-      <div class="mx-auto max-w-5xl py-6">
-        <div class="grid gap-6">
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Supported icon names</h2>
-            <div class="flex flex-wrap gap-2">
-              <code
-                v-for="iconName in iconNames"
-                :key="iconName"
-                class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1"
-              >
-                {{ iconName }}
-              </code>
-            </div>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Size contract</h2>
-            <div class="overflow-auto">
-              <table class="min-w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Size</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Token</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="item in sizeRows" :key="item.size">
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.size }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.token }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                      <code>{{ item.classOutput }}</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Rotation contract</h2>
-            <div class="overflow-auto">
-              <table class="min-w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Rotation</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="item in rotationRows" :key="item.rotation">
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.rotation }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                      <code>{{ item.classOutput }}</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Variant contract</h2>
-            <div class="overflow-auto">
-              <table class="min-w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Variant</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Token</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="item in variantRows" :key="item.variant">
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.variant }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.token }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                      <code>{{ item.classOutput }}</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">SVG rendering contract</h2>
+    template: createContractPageTemplate(`
+${createContractSectionTemplate({
+  body: createCodeChipListTemplate({
+    itemAlias: 'iconName',
+    itemsExpression: 'iconNames',
+    keyExpression: 'iconName',
+  }),
+  title: 'Supported icon names',
+})}
+${createContractSectionTemplate({
+  body: createContractTableTemplate({
+    columns: [
+      {
+        header: 'Size',
+        valueExpression: 'item.size',
+      },
+      {
+        header: 'Token',
+        valueExpression: 'item.token',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.classOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'sizeRows',
+    rowKeyExpression: 'item.size',
+  }),
+  title: 'Size contract',
+})}
+${createContractSectionTemplate({
+  body: createContractTableTemplate({
+    columns: [
+      {
+        header: 'Rotation',
+        valueExpression: 'item.rotation',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.classOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'rotationRows',
+    rowKeyExpression: 'item.rotation',
+  }),
+  title: 'Rotation contract',
+})}
+${createContractSectionTemplate({
+  body: createContractTableTemplate({
+    columns: [
+      {
+        header: 'Variant',
+        valueExpression: 'item.variant',
+      },
+      {
+        header: 'Token',
+        valueExpression: 'item.token',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.classOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'variantRows',
+    rowKeyExpression: 'item.variant',
+  }),
+  title: 'Variant contract',
+})}
+${createContractSectionTemplate({
+  body: `
             <p class="m-0 text-sm text-[var(--color-text-secondary)]">
               All current icons are authored as 24 by 24 stroke-based paths. The primitive enforces
               <code> fill="none" </code>, <code>stroke="currentColor"</code>, a stroke width of
               <code> 2 </code>, and round line caps and joins across every icon.
             </p>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Accessibility contract</h2>
+  `,
+  title: 'SVG rendering contract',
+})}
+${createContractSectionTemplate({
+  body: `
             <p class="m-0 text-sm text-[var(--color-text-secondary)]">
               Icons without <code>label</code> or <code>aria-label</code> are decorative and hidden
               from assistive technology. If both are provided, <code>label</code> wins.
             </p>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Why Icon is static</h2>
+  `,
+  title: 'Accessibility contract',
+})}
+${createContractSectionTemplate({
+  body: `
             <p class="m-0 text-sm text-[var(--color-text-secondary)]">
               Icon is a small SVG primitive for consistent shape, size, color, and accessibility.
               It does not own click behavior, button semantics, or link semantics.
@@ -169,9 +161,9 @@ export const Overview: Story = {
               Interactive icon-only behavior belongs to <code>IconButton</code>, where hit target,
               focus treatment, and action semantics can be handled deliberately.
             </p>
-          </section>
-        </div>
-      </div>
-    `,
+  `,
+  title: 'Why Icon is static',
+})}
+    `),
   }),
 };

--- a/apps/frontend-docs/hub/src/stories/LoadingOverview.stories.ts
+++ b/apps/frontend-docs/hub/src/stories/LoadingOverview.stories.ts
@@ -46,7 +46,7 @@ export const Overview: Story = {
       };
     },
     template: `
-      <div class="mx-auto w-full max-w-5xl px-4 py-6">
+      <div class="mx-auto max-w-5xl py-6">
         <div class="grid gap-6">
           <section class="grid gap-2">
             <h2 class="m-0 text-base font-semibold">Supported sizes</h2>

--- a/apps/frontend-docs/hub/src/stories/LoadingOverview.stories.ts
+++ b/apps/frontend-docs/hub/src/stories/LoadingOverview.stories.ts
@@ -1,4 +1,11 @@
 import {
+  createCodeChipListTemplate,
+  createContractPageTemplate,
+  createContractSectionTemplate,
+  createContractTableTemplate,
+  createSubsectionTemplate,
+} from '@frontend-docs-shared/storybook/hubContractTemplates';
+import {
   circularProgressVariants,
   type LoadingColor,
   type LoadingSize,
@@ -45,191 +52,157 @@ export const Overview: Story = {
         sizeRows,
       };
     },
-    template: `
-      <div class="mx-auto max-w-5xl py-6">
-        <div class="grid gap-6">
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Supported sizes</h2>
-            <div class="flex flex-wrap gap-2">
-              <code
-                v-for="size in sizeRows"
-                :key="size.size"
-                class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1"
-              >
-                {{ size.size }}
-              </code>
-            </div>
-          </section>
-
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Supported colors</h2>
-            <div class="flex flex-wrap gap-2">
-              <code
-                v-for="color in colorRows"
-                :key="color.color"
-                class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1"
-              >
-                {{ color.color }}
-              </code>
-            </div>
-          </section>
-
-          <section class="grid gap-4">
-            <h2 class="m-0 text-base font-semibold">Size contract</h2>
+    template: createContractPageTemplate(`
+${createContractSectionTemplate({
+  body: createCodeChipListTemplate({
+    itemAlias: 'size',
+    itemsExpression: 'sizeRows',
+    keyExpression: 'size.size',
+    valueExpression: 'size.size',
+  }),
+  title: 'Supported sizes',
+})}
+${createContractSectionTemplate({
+  body: createCodeChipListTemplate({
+    itemAlias: 'color',
+    itemsExpression: 'colorRows',
+    keyExpression: 'color.color',
+    valueExpression: 'color.color',
+  }),
+  title: 'Supported colors',
+})}
+${createContractSectionTemplate({
+  body: `
             <div class="grid gap-4">
-              <section class="grid gap-2">
-                <h3 class="m-0 text-sm font-semibold">Loader</h3>
-                <div class="overflow-auto">
-                  <table class="min-w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Size</th>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="item in sizeRows" :key="\`loader-\${item.size}\`">
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                          <code>{{ item.size }}</code>
-                        </td>
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                          <code>{{ item.loaderClassOutput }}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </section>
-
-              <section class="grid gap-2">
-                <h3 class="m-0 text-sm font-semibold">Progress</h3>
-                <div class="overflow-auto">
-                  <table class="min-w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Size</th>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="item in sizeRows" :key="\`progress-\${item.size}\`">
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                          <code>{{ item.size }}</code>
-                        </td>
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                          <code>{{ item.progressClassOutput }}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </section>
-
-              <section class="grid gap-2">
-                <h3 class="m-0 text-sm font-semibold">CircularProgress</h3>
-                <div class="overflow-auto">
-                  <table class="min-w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Size</th>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="item in sizeRows" :key="\`circular-\${item.size}\`">
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                          <code>{{ item.size }}</code>
-                        </td>
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                          <code>{{ item.circularClassOutput }}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </section>
+${createSubsectionTemplate(
+  'Loader',
+  createContractTableTemplate({
+    columns: [
+      {
+        header: 'Size',
+        valueExpression: 'item.size',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.loaderClassOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'sizeRows',
+    rowKeyExpression: "'loader-' + item.size",
+  }),
+)}
+${createSubsectionTemplate(
+  'Progress',
+  createContractTableTemplate({
+    columns: [
+      {
+        header: 'Size',
+        valueExpression: 'item.size',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.progressClassOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'sizeRows',
+    rowKeyExpression: "'progress-' + item.size",
+  }),
+)}
+${createSubsectionTemplate(
+  'CircularProgress',
+  createContractTableTemplate({
+    columns: [
+      {
+        header: 'Size',
+        valueExpression: 'item.size',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.circularClassOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'sizeRows',
+    rowKeyExpression: "'circular-' + item.size",
+  }),
+)}
             </div>
-          </section>
-
-          <section class="grid gap-4">
-            <h2 class="m-0 text-base font-semibold">Color contract</h2>
+  `,
+  className: 'grid gap-4',
+  title: 'Size contract',
+})}
+${createContractSectionTemplate({
+  body: `
             <div class="grid gap-4">
-              <section class="grid gap-2">
-                <h3 class="m-0 text-sm font-semibold">Loader</h3>
-                <div class="overflow-auto">
-                  <table class="min-w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Color</th>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="item in colorRows" :key="\`loader-\${item.color}\`">
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                          <code>{{ item.color }}</code>
-                        </td>
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                          <code>{{ item.loaderClassOutput }}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </section>
-
-              <section class="grid gap-2">
-                <h3 class="m-0 text-sm font-semibold">Progress</h3>
-                <div class="overflow-auto">
-                  <table class="min-w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Color</th>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="item in colorRows" :key="\`progress-\${item.color}\`">
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                          <code>{{ item.color }}</code>
-                        </td>
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                          <code>{{ item.progressClassOutput }}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </section>
-
-              <section class="grid gap-2">
-                <h3 class="m-0 text-sm font-semibold">CircularProgress</h3>
-                <div class="overflow-auto">
-                  <table class="min-w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Color</th>
-                        <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="item in colorRows" :key="\`circular-\${item.color}\`">
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                          <code>{{ item.color }}</code>
-                        </td>
-                        <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                          <code>{{ item.circularClassOutput }}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </section>
+${createSubsectionTemplate(
+  'Loader',
+  createContractTableTemplate({
+    columns: [
+      {
+        header: 'Color',
+        valueExpression: 'item.color',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.loaderClassOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'colorRows',
+    rowKeyExpression: "'loader-' + item.color",
+  }),
+)}
+${createSubsectionTemplate(
+  'Progress',
+  createContractTableTemplate({
+    columns: [
+      {
+        header: 'Color',
+        valueExpression: 'item.color',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.progressClassOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'colorRows',
+    rowKeyExpression: "'progress-' + item.color",
+  }),
+)}
+${createSubsectionTemplate(
+  'CircularProgress',
+  createContractTableTemplate({
+    columns: [
+      {
+        header: 'Color',
+        valueExpression: 'item.color',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.circularClassOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'colorRows',
+    rowKeyExpression: "'circular-' + item.color",
+  }),
+)}
             </div>
-          </section>
-
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Behavior contract</h2>
+  `,
+  className: 'grid gap-4',
+  title: 'Color contract',
+})}
+${createContractSectionTemplate({
+  body: `
             <p class="m-0 text-sm text-[var(--color-text-secondary)]">
               <code>Progress</code> supports determinate and indeterminate states. Indeterminate state
               is represented by adding <code>progress--indeterminate</code> to the class output and uses
@@ -243,19 +216,20 @@ export const Overview: Story = {
               Fraction value display in <code>CircularProgress</code> adds
               <code> circular-progress__value--fraction </code> to reduce value text size by about 2px.
             </p>
-          </section>
-
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Key loading tokens</h2>
+  `,
+  title: 'Behavior contract',
+})}
+${createContractSectionTemplate({
+  body: `
             <div class="flex flex-wrap gap-2">
               <code class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1">--size-loading-progress-indeterminate-segment</code>
               <code class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1">--size-loading-progress-reduced-motion-segment</code>
               <code class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1">--motion-duration-extended</code>
               <code class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1">--motion-duration-sustained</code>
             </div>
-          </section>
-        </div>
-      </div>
-    `,
+  `,
+  title: 'Key loading tokens',
+})}
+    `),
   }),
 };

--- a/apps/frontend-docs/hub/src/stories/TypographyOverview.stories.ts
+++ b/apps/frontend-docs/hub/src/stories/TypographyOverview.stories.ts
@@ -37,7 +37,7 @@ export const Overview: Story = {
       };
     },
     template: `
-      <div class="mx-auto w-full max-w-5xl px-4 py-6">
+      <div class="mx-auto max-w-5xl py-6">
         <div class="grid gap-6">
           <section class="grid gap-2">
             <h2 class="m-0 text-base font-semibold">Supported tags</h2>

--- a/apps/frontend-docs/hub/src/stories/TypographyOverview.stories.ts
+++ b/apps/frontend-docs/hub/src/stories/TypographyOverview.stories.ts
@@ -1,4 +1,10 @@
 import {
+  createCodeChipListTemplate,
+  createContractPageTemplate,
+  createContractSectionTemplate,
+  createContractTableTemplate,
+} from '@frontend-docs-shared/storybook/hubContractTemplates';
+import {
   resolveTypographyDefaultTag,
   supportedTypographyTags,
   type TypographyVariant,
@@ -36,50 +42,38 @@ export const Overview: Story = {
         variants,
       };
     },
-    template: `
-      <div class="mx-auto max-w-5xl py-6">
-        <div class="grid gap-6">
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Supported tags</h2>
-            <div class="flex flex-wrap gap-2">
-              <code
-                v-for="tag in supportedTags"
-                :key="tag"
-                class="rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1"
-              >
-                {{ tag }}
-              </code>
-            </div>
-          </section>
-          <section class="grid gap-2">
-            <h2 class="m-0 text-base font-semibold">Variant contract</h2>
-            <div class="overflow-auto">
-              <table class="min-w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Variant</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Default tag</th>
-                    <th class="border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold">Class output</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="item in variants" :key="item.variant">
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.variant }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top">
-                      <code>{{ item.defaultTag }}</code>
-                    </td>
-                    <td class="border-b border-[var(--color-border-muted)] p-2 align-top break-all">
-                      <code>{{ item.classOutput }}</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </section>
-        </div>
-      </div>
-    `,
+    template: createContractPageTemplate(`
+${createContractSectionTemplate({
+  body: createCodeChipListTemplate({
+    itemAlias: 'tag',
+    itemsExpression: 'supportedTags',
+    keyExpression: 'tag',
+  }),
+  title: 'Supported tags',
+})}
+${createContractSectionTemplate({
+  body: createContractTableTemplate({
+    columns: [
+      {
+        header: 'Variant',
+        valueExpression: 'item.variant',
+      },
+      {
+        header: 'Default tag',
+        valueExpression: 'item.defaultTag',
+      },
+      {
+        breakAll: true,
+        header: 'Class output',
+        valueExpression: 'item.classOutput',
+      },
+    ],
+    rowItemAlias: 'item',
+    rowItemsExpression: 'variants',
+    rowKeyExpression: 'item.variant',
+  }),
+  title: 'Variant contract',
+})}
+    `),
   }),
 };

--- a/apps/frontend-docs/shared/docs/DesignSystemDocsPage.tsx
+++ b/apps/frontend-docs/shared/docs/DesignSystemDocsPage.tsx
@@ -6,9 +6,11 @@ import { renderDocsSections } from './renderDocsSections';
 import { SourceLinksList } from './SourceLinksList';
 import type { SourceLink } from './sourceLinks';
 
-const pageClassName = 'px-4 py-6 md:px-6 md:py-8';
-const contentClassName = 'mx-auto grid w-full max-w-5xl gap-8';
+const pageClassName = 'py-6 md:py-8';
+const contentClassName = 'mx-auto grid max-w-5xl gap-8';
 const sectionClassName = 'grid gap-4';
+const controlsContentClassName =
+  'min-w-0 [&>div]:overflow-x-auto [&_code]:whitespace-normal [&_code]:[overflow-wrap:anywhere]';
 
 type DocsSectionBlockProps = {
   children: ReactNode;
@@ -53,7 +55,7 @@ export function DesignSystemDocsPage({
         title: 'Examples',
       }),
       createElement(DocsSectionBlock, {
-        children: controls,
+        children: createElement('div', { className: controlsContentClassName }, controls),
         key: 'controls',
         title: 'Controls',
       }),

--- a/apps/frontend-docs/shared/docs/FrameworkComponentDocsPage.tsx
+++ b/apps/frontend-docs/shared/docs/FrameworkComponentDocsPage.tsx
@@ -1,0 +1,98 @@
+import { createElement, type ElementType, Fragment, type ReactNode } from 'react';
+
+import { DesignSystemDocsPage } from './DesignSystemDocsPage';
+import { DocsExample } from './DocsExample';
+import type { ComponentDocs } from './docsTypes';
+import { createFrameworkSourceLinks, type SourceLink } from './sourceLinks';
+
+type StoryReference = {
+  name?: string;
+  storyName?: string;
+};
+
+type ControlSection = {
+  story: StoryReference;
+  title?: string;
+};
+
+type FrameworkComponentDocsPageProps = {
+  argTypesBlock: ElementType<{ of: unknown }>;
+  canvasBlock: ElementType<{ of: unknown }>;
+  contractSourceLinks: readonly SourceLink[];
+  controls: readonly ControlSection[];
+  docs: ComponentDocs;
+  examples: readonly StoryReference[];
+  framework: 'React' | 'Vue';
+  implementationPath: string;
+  storiesPath: string;
+};
+
+function renderControls(
+  ArgTypesBlock: ElementType<{ of: unknown }>,
+  controls: readonly ControlSection[],
+): ReactNode {
+  const content: ReactNode[] = [];
+
+  for (const [index, control] of controls.entries()) {
+    if (control.title) {
+      content.push(
+        createElement(
+          'h3',
+          {
+            className: 'm-0',
+            key: `heading-${index}`,
+          },
+          control.title,
+        ),
+      );
+    }
+
+    content.push(
+      createElement(ArgTypesBlock, {
+        key: `arg-types-${index}`,
+        of: control.story,
+      }),
+    );
+  }
+
+  return createElement(Fragment, null, content);
+}
+
+function renderExamples(
+  CanvasBlock: ElementType<{ of: unknown }>,
+  examples: readonly StoryReference[],
+): ReactNode {
+  return createElement(
+    Fragment,
+    null,
+    examples.map((story, index) =>
+      createElement(DocsExample, {
+        key: `example-${index}`,
+        children: createElement(CanvasBlock, { of: story }),
+        story,
+      }),
+    ),
+  );
+}
+
+export function FrameworkComponentDocsPage({
+  argTypesBlock: ArgTypesBlock,
+  canvasBlock: CanvasBlock,
+  contractSourceLinks,
+  controls,
+  docs,
+  examples,
+  framework,
+  implementationPath,
+  storiesPath,
+}: FrameworkComponentDocsPageProps) {
+  return createElement(DesignSystemDocsPage, {
+    controls: renderControls(ArgTypesBlock, controls),
+    docs,
+    examples: renderExamples(CanvasBlock, examples),
+    sourceLinks: [
+      ...contractSourceLinks,
+      ...createFrameworkSourceLinks(framework, implementationPath, storiesPath),
+    ],
+  });
+}

--- a/apps/frontend-docs/shared/docs/SourceLinksList.tsx
+++ b/apps/frontend-docs/shared/docs/SourceLinksList.tsx
@@ -4,6 +4,9 @@ import { createSourceUrl, type SourceLink } from './sourceLinks';
 
 const sourceListClassName = 'grid gap-3';
 const sourceItemsClassName = '!m-0 grid gap-1 !pl-5';
+const sourcePathStyle = {
+  whiteSpace: 'normal',
+} as const;
 
 export function SourceLinksList({ links }: { links: readonly SourceLink[] }) {
   return createElement('section', { className: sourceListClassName }, [
@@ -27,7 +30,14 @@ export function SourceLinksList({ links }: { links: readonly SourceLink[] }) {
             link.label,
           ),
           ' ',
-          createElement('code', { key: 'path' }, link.path),
+          createElement(
+            'code',
+            {
+              key: 'path',
+              style: sourcePathStyle,
+            },
+            link.path,
+          ),
         ]),
       ),
     ),

--- a/apps/frontend-docs/shared/storybook/config.ts
+++ b/apps/frontend-docs/shared/storybook/config.ts
@@ -1,3 +1,6 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 export const frontendDocsCoreConfig = {
   allowedHosts: true,
 } as const;
@@ -29,4 +32,133 @@ export function createFrontendDocsViteOptions({ aliases, host, plugins }: Fronte
       allowedHosts: true,
     },
   };
+}
+
+type FrontendDocsFrameworkName = '@storybook/react-vite' | '@storybook/vue3-vite';
+type FrontendDocsAddon = string | { name: string; options?: unknown };
+type ViteConfigLike = Record<string, unknown>;
+
+type FrontendDocsRefEntry =
+  | {
+      title: string;
+      url: string;
+    }
+  | {
+      disable: true;
+    };
+
+type FrontendDocsStorybookConfigOptions = {
+  addons: readonly FrontendDocsAddon[];
+  frameworkName: FrontendDocsFrameworkName;
+  host: string;
+  mainFileUrl: string;
+  refs?: () => Record<string, FrontendDocsRefEntry>;
+  stories: readonly string[];
+  viteAliases?: Record<string, string>;
+  viteConfigOverride?: ViteConfigLike;
+  vitePlugins: unknown[];
+};
+
+function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return {};
+}
+
+function mergeViteLikeConfig(base: ViteConfigLike, extension: ViteConfigLike): ViteConfigLike {
+  const baseResolve = asRecord(base.resolve);
+  const extensionResolve = asRecord(extension.resolve);
+  const mergedResolve = {
+    ...baseResolve,
+    ...extensionResolve,
+    alias: {
+      ...asRecord(baseResolve.alias),
+      ...asRecord(extensionResolve.alias),
+    },
+  };
+  const baseServer = asRecord(base.server);
+  const extensionServer = asRecord(extension.server);
+  const mergedServer = {
+    ...baseServer,
+    ...extensionServer,
+  };
+  const baseCss = asRecord(base.css);
+  const extensionCss = asRecord(extension.css);
+  const basePostcss = asRecord(baseCss.postcss);
+  const extensionPostcss = asRecord(extensionCss.postcss);
+  const mergedCss = {
+    ...baseCss,
+    ...extensionCss,
+    postcss: {
+      ...basePostcss,
+      ...extensionPostcss,
+      plugins: [...asArray(basePostcss.plugins), ...asArray(extensionPostcss.plugins)],
+    },
+  };
+
+  return {
+    ...base,
+    ...extension,
+    css: mergedCss,
+    plugins: [...asArray(base.plugins), ...asArray(extension.plugins)],
+    resolve: mergedResolve,
+    server: mergedServer,
+  };
+}
+
+export function createFrontendDocsStorybookConfig<TConfig>({
+  addons,
+  frameworkName,
+  host,
+  mainFileUrl,
+  refs,
+  stories,
+  viteAliases,
+  viteConfigOverride,
+  vitePlugins,
+}: FrontendDocsStorybookConfigOptions): TConfig {
+  return {
+    addons: [...addons],
+    core: frontendDocsCoreConfig,
+    framework: {
+      name: frameworkName,
+      options: {},
+    },
+    refs,
+    stories,
+    async viteFinal(existingViteConfig: ViteConfigLike) {
+      const currentDirectory = path.dirname(fileURLToPath(mainFileUrl));
+      const frontendDocsSharedRoot = path.resolve(currentDirectory, '../../shared');
+      const aliasMap: Record<string, string> = {
+        '@frontend-docs-shared': frontendDocsSharedRoot,
+      };
+
+      if (viteAliases) {
+        Object.assign(aliasMap, viteAliases);
+      }
+
+      const baseViteConfig = createFrontendDocsViteOptions({
+        aliases: aliasMap,
+        host,
+        plugins: [...vitePlugins],
+      });
+      const mergedViteConfig = mergeViteLikeConfig(existingViteConfig, baseViteConfig);
+
+      if (viteConfigOverride) {
+        return mergeViteLikeConfig(mergedViteConfig, viteConfigOverride);
+      }
+
+      return mergedViteConfig;
+    },
+  } as TConfig;
 }

--- a/apps/frontend-docs/shared/storybook/hubContractTemplates.ts
+++ b/apps/frontend-docs/shared/storybook/hubContractTemplates.ts
@@ -1,0 +1,180 @@
+type ContractSectionTemplateOptions = {
+  body: string;
+  className?: string;
+  headingClassName?: string;
+  headingLevel?: 'h2' | 'h3';
+  title: string;
+};
+
+type CodeChipListTemplateOptions = {
+  itemAlias: string;
+  itemsExpression: string;
+  keyExpression: string;
+  valueExpression?: string;
+};
+
+type ContractTableColumn = {
+  breakAll?: boolean;
+  header: string;
+  valueExpression: string;
+};
+
+type ContractTableTemplateOptions = {
+  columns: readonly ContractTableColumn[];
+  rowItemAlias: string;
+  rowItemsExpression: string;
+  rowKeyExpression: string;
+};
+
+const pageClassName = 'mx-auto max-w-5xl py-6';
+const pageGridClassName = 'grid gap-6';
+const sectionClassName = 'grid gap-2';
+const sectionHeadingClassName = 'm-0 text-base font-semibold';
+const subsectionHeadingClassName = 'm-0 text-sm font-semibold';
+const chipClassName = 'rounded-[var(--radius-sm)] bg-[var(--color-surface-secondary)] px-2 py-1';
+const tableHeadCellClassName =
+  'border-b border-[var(--color-border-default)] p-2 text-left align-top text-sm font-semibold';
+const tableCellClassName = 'border-b border-[var(--color-border-muted)] p-2 align-top';
+
+function dedent(content: string): string {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+
+  while (lines.length > 0 && lines[0].trim().length === 0) {
+    lines.shift();
+  }
+
+  while (lines.length > 0 && lines[lines.length - 1].trim().length === 0) {
+    lines.pop();
+  }
+
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+
+  if (nonEmptyLines.length === 0) {
+    return '';
+  }
+
+  const minIndent = Math.min(
+    ...nonEmptyLines.map((line) => {
+      const match = line.match(/^ */);
+
+      if (!match) {
+        return 0;
+      }
+
+      return match[0].length;
+    }),
+  );
+
+  return lines.map((line) => line.slice(minIndent)).join('\n');
+}
+
+function indent(content: string, spaces: number): string {
+  const normalized = dedent(content);
+
+  if (normalized.length === 0) {
+    return '';
+  }
+
+  const prefix = ' '.repeat(spaces);
+
+  return normalized
+    .split('\n')
+    .map((line) => `${prefix}${line}`)
+    .join('\n');
+}
+
+export function createContractPageTemplate(body: string): string {
+  return [
+    `<div class="${pageClassName}">`,
+    `  <div class="${pageGridClassName}">`,
+    indent(body, 4),
+    '  </div>',
+    '</div>',
+  ].join('\n');
+}
+
+export function createContractSectionTemplate({
+  body,
+  className = sectionClassName,
+  headingClassName = sectionHeadingClassName,
+  headingLevel = 'h2',
+  title,
+}: ContractSectionTemplateOptions): string {
+  return [
+    `<section class="${className}">`,
+    `  <${headingLevel} class="${headingClassName}">${title}</${headingLevel}>`,
+    indent(body, 2),
+    '</section>',
+  ].join('\n');
+}
+
+export function createCodeChipListTemplate({
+  itemAlias,
+  itemsExpression,
+  keyExpression,
+  valueExpression,
+}: CodeChipListTemplateOptions): string {
+  const resolvedValueExpression = valueExpression ?? itemAlias;
+
+  return [
+    '<div class="flex flex-wrap gap-2">',
+    '  <code',
+    `    v-for="${itemAlias} in ${itemsExpression}"`,
+    `    :key="${keyExpression}"`,
+    `    class="${chipClassName}"`,
+    '  >',
+    `    {{ ${resolvedValueExpression} }}`,
+    '  </code>',
+    '</div>',
+  ].join('\n');
+}
+
+export function createContractTableTemplate({
+  columns,
+  rowItemAlias,
+  rowItemsExpression,
+  rowKeyExpression,
+}: ContractTableTemplateOptions): string {
+  const tableHeader = columns
+    .map((column) => {
+      return `<th class="${tableHeadCellClassName}">${column.header}</th>`;
+    })
+    .join('\n');
+  const tableCells = columns
+    .map((column) => {
+      const breakAllClassName = column.breakAll ? ' break-all' : '';
+
+      return [
+        `<td class="${tableCellClassName}${breakAllClassName}">`,
+        `  <code>{{ ${column.valueExpression} }}</code>`,
+        '</td>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<div class="overflow-auto">',
+    '  <table class="min-w-full border-collapse">',
+    '    <thead>',
+    '      <tr>',
+    indent(tableHeader, 8),
+    '      </tr>',
+    '    </thead>',
+    '    <tbody>',
+    `      <tr v-for="${rowItemAlias} in ${rowItemsExpression}" :key="${rowKeyExpression}">`,
+    indent(tableCells, 8),
+    '      </tr>',
+    '    </tbody>',
+    '  </table>',
+    '</div>',
+  ].join('\n');
+}
+
+export function createSubsectionTemplate(title: string, body: string): string {
+  return [
+    `<section class="${sectionClassName}">`,
+    `  <h3 class="${subsectionHeadingClassName}">${title}</h3>`,
+    indent(body, 2),
+    '</section>',
+  ].join('\n');
+}

--- a/apps/frontend-docs/shared/storybook/reactStoryLayouts.tsx
+++ b/apps/frontend-docs/shared/storybook/reactStoryLayouts.tsx
@@ -1,0 +1,37 @@
+import { createElement, type ReactNode } from 'react';
+
+const stackBaseClassName = 'grid gap-4';
+const infoPanelBaseClassName =
+  'rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4';
+
+type StoryStackProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+type StoryInfoPanelProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+function joinClassNames(...classNames: Array<string | undefined>): string {
+  return classNames
+    .filter((className) => className !== undefined && className.length > 0)
+    .join(' ');
+}
+
+export function StoryStack({ children, className }: StoryStackProps) {
+  return createElement(
+    'div',
+    { className: joinClassNames(stackBaseClassName, className) },
+    children,
+  );
+}
+
+export function StoryInfoPanel({ children, className }: StoryInfoPanelProps) {
+  return createElement(
+    'div',
+    { className: joinClassNames(infoPanelBaseClassName, className) },
+    children,
+  );
+}

--- a/apps/frontend-docs/shared/storybook/vueStoryTemplates.ts
+++ b/apps/frontend-docs/shared/storybook/vueStoryTemplates.ts
@@ -1,0 +1,9 @@
+const storyStackClassName = 'grid gap-4';
+
+export function withStoryStack(content: string): string {
+  return `
+    <div class="${storyStackClassName}">
+${content}
+    </div>
+  `;
+}

--- a/apps/frontend-docs/site-nuxt-components/.storybook/main.ts
+++ b/apps/frontend-docs/site-nuxt-components/.storybook/main.ts
@@ -5,49 +5,38 @@ import type { StorybookConfig } from '@storybook/vue3-vite';
 import tailwindcss from '@tailwindcss/vite';
 import vue from '@vitejs/plugin-vue';
 import postcssNested from 'postcss-nested';
-import { mergeConfig } from 'vite';
 
+import {
+  createFrontendDocsStorybookConfig,
+  frontendDocsDefaultAddons,
+  frontendDocsStoryGlobs,
+} from '../../shared/storybook/config.ts';
 import { siteNuxtAutoImportsPlugin } from './siteNuxtAutoImportsPlugin.ts';
 
 const STORYBOOK_LOCAL_HOST = 'site-nuxt-components.local.hoite.dev';
 const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SITE_NUXT_ROOT = path.resolve(CURRENT_DIR, '../../../site-nuxt');
 
-const config: StorybookConfig = {
-  addons: ['@storybook/addon-docs', '@storybook/addon-a11y'],
-  framework: {
-    name: '@storybook/vue3-vite',
-    options: {},
+const config = createFrontendDocsStorybookConfig<StorybookConfig>({
+  addons: frontendDocsDefaultAddons,
+  frameworkName: '@storybook/vue3-vite',
+  host: STORYBOOK_LOCAL_HOST,
+  mainFileUrl: import.meta.url,
+  stories: frontendDocsStoryGlobs,
+  viteAliases: {
+    '@': SITE_NUXT_ROOT,
+    '~': SITE_NUXT_ROOT,
+    '@site-nuxt': SITE_NUXT_ROOT,
+    'site-nuxt-storybook-runtime': path.resolve(CURRENT_DIR, '../src/siteNuxtStorybookRuntime.ts'),
   },
-  core: {
-    allowedHosts: true,
+  viteConfigOverride: {
+    css: {
+      postcss: {
+        plugins: [postcssNested()],
+      },
+    },
   },
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
-  async viteFinal(config) {
-    return mergeConfig(config, {
-      css: {
-        postcss: {
-          plugins: [postcssNested()],
-        },
-      },
-      plugins: [siteNuxtAutoImportsPlugin(), tailwindcss(), vue()],
-      resolve: {
-        alias: {
-          '@': SITE_NUXT_ROOT,
-          '~': SITE_NUXT_ROOT,
-          '@site-nuxt': SITE_NUXT_ROOT,
-          'site-nuxt-storybook-runtime': path.resolve(
-            CURRENT_DIR,
-            '../src/siteNuxtStorybookRuntime.ts',
-          ),
-        },
-      },
-      server: {
-        host: STORYBOOK_LOCAL_HOST,
-        allowedHosts: true,
-      },
-    });
-  },
-};
+  vitePlugins: [siteNuxtAutoImportsPlugin(), tailwindcss(), vue()],
+});
 
 export default config;

--- a/packages/biome-config/README.md
+++ b/packages/biome-config/README.md
@@ -1,0 +1,17 @@
+# `@hoite-dev/biome-config`
+
+Shared Biome configuration package for the monorepo.
+
+## Purpose
+
+- Provide one reusable Biome base configuration for apps and packages.
+- Keep linting and formatting behavior consistent across the repo.
+
+## Package boundary
+
+- Owns shared Biome config files and related package metadata.
+- Does not own framework-specific lint setup beyond Biome.
+
+## Usage
+
+Extend this package from workspace-level `biome.json` files where needed.

--- a/packages/diagnostics/README.md
+++ b/packages/diagnostics/README.md
@@ -1,0 +1,28 @@
+# `@hoite-dev/diagnostics`
+
+Small shared diagnostics utilities for the monorepo.
+
+## Purpose
+
+- Provide lightweight runtime diagnostics helpers that can be reused across apps and packages.
+- Keep diagnostics behavior centralized instead of repeating local helper functions.
+
+## Current API
+
+- `warnInDevelopment(message, options?)`
+  - Logs with `console.warn` only when `NODE_ENV === 'development'`.
+  - Supports optional deduplication with `options.key` (warn once per key per runtime).
+
+## Usage
+
+```ts
+import { warnInDevelopment } from '@hoite-dev/diagnostics';
+
+warnInDevelopment('Missing optional docs metadata', { key: 'docs:metadata:missing' });
+```
+
+## Scripts
+
+- `pnpm --filter @hoite-dev/diagnostics lint`
+- `pnpm --filter @hoite-dev/diagnostics typecheck`
+- `pnpm --filter @hoite-dev/diagnostics build`

--- a/packages/ui-react/README.md
+++ b/packages/ui-react/README.md
@@ -18,6 +18,6 @@ It builds on the shared styling foundation from `@hoite-dev/ui` and exposes Reac
 Shared foundations such as tokens and contract-level documentation belong in `apps/frontend-docs/hub`.
 
 React implementation stories belong in `apps/frontend-docs/design-system-react` and should prove that the React wrappers render the shared contract correctly.
-When a Vue component docs page should match the React docs page, create an attached MDX page in `apps/frontend-docs/design-system-react`.
+When a React component docs page should match the Vue docs page, create an attached MDX page in `apps/frontend-docs/design-system-react`.
 
 Use shared docs metadata from `@hoite-dev/ui` where possible, instead of repeating the same explanatory text in each story file.


### PR DESCRIPTION
## Frontend design docs fixes & ad hoc cleanup

- Consolidates Storybook setup across the frontend docs apps by introducing a shared config factory (including safer Vite config merging) and switching React, Vue, hub, and site-nuxt-components to that common path.
- Refactors the docs/stories layer to reuse shared building blocks (`FrameworkComponentDocsPage`, shared story layout wrappers, and hub contract template helpers), which aligns React/Vue/Hub docs structure and removes a lot of duplicated template markup.
- Adds a docs consistency playbook/checklist for future contributors and fills missing package docs references/readmes (`diagnostics`, `biome-config`) so workspace documentation is more complete and navigable.
