### PR TITLE
Feature/frontend docs  playground improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It contains the Hoite Dev site app, frontend documentation, shared design system
 - [Development setup and commands](./DEVELOPMENT.md)
 - [Workspace overview](#workspace-overview)
 - [Workspace docs](#workspace-docs)
+- [Third-party notices](#third-party-notices)
 - [License](#license)
 
 ## Workspace overview
@@ -127,6 +128,11 @@ Storybook addon for synchronizing theme state across the manager, preview, and c
 AI is used as a support tool for ideation, technical planning, refactoring support, documentation, and language refinement.
 
 It helps accelerate exploration and iteration, while final decisions, validation, and implementation remain my responsibility.
+
+## Third-party notices
+
+This project includes third-party assets and code.
+See [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md) for details.
 
 ## License
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,49 @@
+# Third-party notices
+
+## Tabler Icons
+
+This project includes SVG path data derived from Tabler Icons.
+
+[Tabler Icons](https://github.com/tabler/tabler-icons) is licensed under the MIT License.
+
+MIT License
+
+Copyright (c) 2020-2026 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Open Sans
+
+This project includes Open Sans font files.
+
+[Open Sans](https://github.com/googlefonts/opensans) is licensed under the SIL Open Font License, Version 1.1.
+
+Copyright 2020 The Open Sans Project Authors (https://github.com/googlefonts/opensans)
+
+The full license text is included with the bundled font files at `packages/ui/src/assets/fonts/Open_Sans/OFL.txt`.
+
+## Roboto
+
+This project includes Roboto font files.
+
+[Roboto](https://github.com/googlefonts/roboto-3-classic) is licensed under the SIL Open Font License, Version 1.1.
+
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+The full license text is included with the bundled font files at `packages/ui/src/assets/fonts/Roboto/OFL.txt`.

--- a/apps/frontend-docs/DOCS_CONSISTENCY_README.md
+++ b/apps/frontend-docs/DOCS_CONSISTENCY_README.md
@@ -90,7 +90,7 @@ These helpers live in `hub/src/stories/contractDocs.tsx` and keep contract pages
 ## Controls Rules
 
 - Use `parameters.controls.sort = 'none'` when control order is intentional.
-- Use `createFrontendDocsPlaygroundParameters(...)` for playground stories. The shared default shows Controls and Accessibility, and hides Actions, Interactions, and the Docs Code panel.
+- Use `createFrontendDocsPlaygroundParameters(...)` for playground stories. The shared default shows Controls and Accessibility, hides Actions, Interactions, and the Docs Code panel.
 - A story can deliberately override playground addon visibility through the helper's `addons` option, for example `addons: { actions: true, code: true }`.
 - The shared manager config hides toolbar tools that are not verified for the current stories: Reload story, Measure, Outline, and Vision filter.
 - Use `tags: ['!dev']` for showcase-only stories when needed.

--- a/apps/frontend-docs/README.md
+++ b/apps/frontend-docs/README.md
@@ -21,6 +21,12 @@ Consistency playbook:
 - `DOCS_CONSISTENCY_README.md`: human workflow and usage guide.
 - `DOCS_CONSISTENCY_AGENT_NOTES.md`: short execution checklist for automation-oriented edits.
 
+Storybook composition notes:
+- The unified frontend docs container composes the React and Vue Storybooks through the hub.
+- Storybook 10.4.0 still needs hub-local composition guards for hard-refreshing ref routes, keeping Controls attached to the correct ref iframe, and preserving copied URL `args` on composed ref stories.
+- Those guards live in `hub/.storybook/storybookCompositionPreviewFrameWorkaround.ts`; re-check them after Storybook upgrades.
+- For string select controls whose URL values can look numeric, declare the argType as `{ type: { name: 'string' } }` so copied Storybook URLs such as `args=rotation:90` survive URL parsing and option validation.
+
 Expected long-term use:
 - Document app-specific components such as page sections, content blocks, and composed UI patterns.
 - Follow the same hub/ref pattern that can later be reused for other frontend apps, such as `site-react-components`.

--- a/apps/frontend-docs/design-system-react/.storybook/manager.ts
+++ b/apps/frontend-docs/design-system-react/.storybook/manager.ts
@@ -1,4 +1,15 @@
-import { applyFrontendDocsManagerConfig } from '@hoite-dev/frontend-docs-shared/storybook';
-import { addons } from 'storybook/manager-api';
+import {
+  applyFrontendDocsManagerConfig,
+  registerFrontendDocsPlaygroundCodeTool,
+} from '@hoite-dev/frontend-docs-shared/storybook';
+import * as React from 'react';
+import { Button } from 'storybook/internal/components';
+import { addons, types } from 'storybook/manager-api';
 
 applyFrontendDocsManagerConfig(addons);
+registerFrontendDocsPlaygroundCodeTool({
+  Button,
+  React,
+  addons,
+  types,
+});

--- a/apps/frontend-docs/design-system-react/.storybook/preview.ts
+++ b/apps/frontend-docs/design-system-react/.storybook/preview.ts
@@ -7,10 +7,18 @@ import '@hoite-dev/ui/loading.css';
 import '@hoite-dev/ui/typography.css';
 import '../../shared/storybook/hoiteThemePreview.css';
 
-import { frontendDocsPreviewParameters } from '@hoite-dev/frontend-docs-shared/storybook';
+import {
+  frontendDocsPreviewInitialGlobals,
+  frontendDocsPreviewParameters,
+  setupFrontendDocsPlaygroundCodePreview,
+} from '@hoite-dev/frontend-docs-shared/storybook';
 import type { Preview } from '@storybook/react-vite';
+import { addons } from 'storybook/preview-api';
+
+setupFrontendDocsPlaygroundCodePreview(addons.getChannel());
 
 const preview: Preview = {
+  initialGlobals: frontendDocsPreviewInitialGlobals,
   parameters: frontendDocsPreviewParameters,
 };
 

--- a/apps/frontend-docs/design-system-react/package.json
+++ b/apps/frontend-docs/design-system-react/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear",
-    "predev": "node ../shared/storybook/prepareStorybook.mjs",
+    "prebuild": "node ../shared/storybook/prepareStorybook.mjs",
+    "predev": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear",
     "build": "storybook build",
     "dev": "storybook dev --host design-system-react.local.hoite.dev --port 6007 --https --ssl-cert ../../../ssl/local.hoite.dev.pem --ssl-key ../../../ssl/local.hoite.dev-key.pem",
     "format": "biome check --write .storybook src package.json tsconfig.json README.md",

--- a/apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx
@@ -1,7 +1,11 @@
 import {
+  createFrontendDocsComponentSnippet,
   createFrontendDocsPlaygroundParameters,
   StoryInfoPanel,
-  StoryStack,
+  StoryPlayground,
+  StoryPlaygroundContent,
+  StoryPlaygroundPreview,
+  StoryPlaygroundSnippet,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 import {
   type IconName,
@@ -17,6 +21,8 @@ import {
 import { Icon } from '@hoite-dev/ui-react';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactElement } from 'react';
+
+import { StorybookSourceSnippet } from './StorybookSourceSnippet';
 
 type IconStoryArgs = {
   name: IconName;
@@ -101,27 +107,53 @@ function getShowcaseSurfaceClass(variant: IconVariant): string {
 }
 
 function IconPlaygroundPreview(iconArgs: IconStoryArgs): ReactElement {
+  const snippet = createFrontendDocsComponentSnippet({
+    componentName: 'Icon',
+    framework: 'react',
+    props: [
+      {
+        name: 'label',
+        value: 'Playground icon',
+      },
+      {
+        name: 'name',
+        value: iconArgs.name,
+      },
+      {
+        name: 'rotation',
+        value: iconArgs.rotation,
+      },
+      {
+        name: 'size',
+        value: iconArgs.size,
+      },
+      {
+        name: 'variant',
+        value: iconArgs.variant,
+      },
+    ],
+  });
+
   return (
-    <StoryStack>
+    <StoryPlayground>
       <StoryInfoPanel>
         <p className='m-0 text-sm text-[var(--color-text-primary)]'>
-          Use <code>name</code>, <code>size</code>, <code>rotation</code>, and <code>variant</code>{' '}
-          as the main visual Icon API.
-        </p>
-        <p className='mb-0 mt-3 text-sm text-[var(--color-text-secondary)]'>
-          In app code, meaningful icons should also receive an accessible name with{' '}
-          <code>label</code> or <code>aria-label</code>.
-        </p>
-        <p className='mb-0 mt-3 text-sm text-[var(--color-text-secondary)]'>
-          Supported passthrough attributes stay narrow: <code>id</code>, <code>title</code>,{' '}
-          <code>role</code>, <code>aria-label</code>, and deliberate <code>data-*</code> attributes
-          on the rendered SVG.
+          Meaningful icons need <code>label</code> or <code>aria-label</code>. Supported
+          passthroughs: <code>id</code>, <code>title</code>, <code>role</code>,{' '}
+          <code>aria-label</code>, and deliberate <code>data-*</code> attributes.
         </p>
       </StoryInfoPanel>
-      <div className={getSurfaceClass(iconArgs.variant)}>
-        <Icon {...iconArgs} label='Playground icon' />
-      </div>
-    </StoryStack>
+      <StoryPlaygroundContent split>
+        <StoryPlaygroundPreview>
+          <div className={getSurfaceClass(iconArgs.variant)}>
+            <Icon {...iconArgs} label='Playground icon' />
+          </div>
+        </StoryPlaygroundPreview>
+        <StoryPlaygroundSnippet>
+          <StorybookSourceSnippet code={snippet} />
+        </StoryPlaygroundSnippet>
+      </StoryPlaygroundContent>
+    </StoryPlayground>
   );
 }
 

--- a/apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Icon.stories.tsx
@@ -46,6 +46,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     table: {
       category: 'Component API',
     },
+    type: {
+      name: 'string',
+    },
   },
   size: {
     control: 'select',
@@ -53,6 +56,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     options: supportedIconSizes,
     table: {
       category: 'Component API',
+    },
+    type: {
+      name: 'string',
     },
   },
   rotation: {
@@ -62,6 +68,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     table: {
       category: 'Component API',
     },
+    type: {
+      name: 'string',
+    },
   },
   variant: {
     control: 'select',
@@ -69,6 +78,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     options: supportedIconVariants,
     table: {
       category: 'Component API',
+    },
+    type: {
+      name: 'string',
     },
   },
 };

--- a/apps/frontend-docs/design-system-react/src/stories/Loading.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Loading.stories.tsx
@@ -1,6 +1,11 @@
 import {
+  createFrontendDocsComponentSnippet,
   createFrontendDocsPlaygroundParameters,
   StoryInfoPanel,
+  StoryPlayground,
+  StoryPlaygroundContent,
+  StoryPlaygroundPreview,
+  StoryPlaygroundSnippet,
   StoryStack,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 import {
@@ -12,6 +17,8 @@ import {
 } from '@hoite-dev/ui';
 import { CircularProgress, Loader, Progress } from '@hoite-dev/ui-react';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/react-vite';
+
+import { StorybookSourceSnippet } from './StorybookSourceSnippet';
 
 type CircularValueDisplay = 'fraction' | 'percent';
 
@@ -176,16 +183,42 @@ export const LoaderPlayground: Story = {
   }),
   render: (args) => {
     const ariaLabel = hasText(args.ariaLabel) ? args.ariaLabel : undefined;
+    const snippet = createFrontendDocsComponentSnippet({
+      componentName: 'Loader',
+      framework: 'react',
+      props: [
+        {
+          name: 'aria-label',
+          value: ariaLabel,
+        },
+        {
+          name: 'color',
+          value: args.color,
+        },
+        {
+          name: 'size',
+          value: args.size,
+        },
+      ],
+    });
 
     return (
-      <StoryStack>
+      <StoryPlayground>
         <StoryInfoPanel className='text-sm text-[var(--color-text-secondary)]'>
-          Loader uses `aria-label` or `aria-labelledby` when it is not decorative.
+          Use <code>aria-label</code> or <code>aria-labelledby</code> when no visible label is
+          present.
         </StoryInfoPanel>
-        <div className={getSurfaceClass(args.color)}>
-          <Loader aria-label={ariaLabel} color={args.color} size={args.size} />
-        </div>
-      </StoryStack>
+        <StoryPlaygroundContent split>
+          <StoryPlaygroundPreview>
+            <div className={getSurfaceClass(args.color)}>
+              <Loader aria-label={ariaLabel} color={args.color} size={args.size} />
+            </div>
+          </StoryPlaygroundPreview>
+          <StoryPlaygroundSnippet>
+            <StorybookSourceSnippet code={snippet} />
+          </StoryPlaygroundSnippet>
+        </StoryPlaygroundContent>
+      </StoryPlayground>
     );
   },
 };
@@ -202,24 +235,63 @@ export const ProgressPlayground: Story = {
     const ariaLabel = hasText(args.ariaLabel) ? args.ariaLabel : undefined;
     const label = hasText(args.label) ? args.label : undefined;
     const value = args.indeterminate ? undefined : args.value;
+    const snippet = createFrontendDocsComponentSnippet({
+      componentName: 'Progress',
+      framework: 'react',
+      props: [
+        {
+          name: 'aria-label',
+          value: ariaLabel,
+        },
+        {
+          name: 'color',
+          value: args.color,
+        },
+        {
+          name: 'label',
+          value: label,
+        },
+        {
+          name: 'max',
+          value: args.max,
+        },
+        {
+          name: 'size',
+          value: args.size,
+        },
+        {
+          name: 'value',
+          value,
+        },
+      ],
+    });
 
     return (
-      <StoryStack>
+      <StoryPlayground>
         <StoryInfoPanel className='text-sm text-[var(--color-text-secondary)]'>
-          Progress uses native <code>&lt;progress&gt;</code> semantics with shared numeric
-          normalization.
+          Indeterminate progress omits <code>value</code>; otherwise value is normalized against{' '}
+          <code>max</code>.
         </StoryInfoPanel>
-        <div className={getSurfaceClass(args.color)}>
-          <Progress
-            aria-label={ariaLabel}
-            color={args.color}
-            label={label}
-            max={args.max}
-            size={args.size}
-            value={value}
-          />
-        </div>
-      </StoryStack>
+        <StoryPlaygroundContent split>
+          <StoryPlaygroundPreview className='min-w-0 w-full'>
+            <div
+              className={`${getSurfaceClass(args.color)} box-border w-full [&_.progress-field]:w-full`}
+            >
+              <Progress
+                aria-label={ariaLabel}
+                color={args.color}
+                label={label}
+                max={args.max}
+                size={args.size}
+                value={value}
+              />
+            </div>
+          </StoryPlaygroundPreview>
+          <StoryPlaygroundSnippet>
+            <StorybookSourceSnippet code={snippet} />
+          </StoryPlaygroundSnippet>
+        </StoryPlaygroundContent>
+      </StoryPlayground>
     );
   },
 };
@@ -248,27 +320,89 @@ export const CircularProgressPlayground: Story = {
     const ariaLabel = hasText(args.ariaLabel) ? args.ariaLabel : undefined;
     const label = hasText(args.label) ? args.label : undefined;
     const valueLabel = hasText(args.valueLabel) ? args.valueLabel : undefined;
+    const labelClassName = args.labelClassName || undefined;
+    const valueClassName = args.valueClassName || undefined;
+    const snippet = createFrontendDocsComponentSnippet({
+      componentName: 'CircularProgress',
+      framework: 'react',
+      props: [
+        {
+          name: 'aria-label',
+          value: ariaLabel,
+        },
+        {
+          name: 'color',
+          value: args.color,
+        },
+        {
+          name: 'label',
+          value: label,
+        },
+        {
+          name: 'labelClassName',
+          value: labelClassName,
+        },
+        {
+          name: 'max',
+          value: args.max,
+        },
+        {
+          defaultValue: true,
+          name: 'showValue',
+          value: args.showValue,
+        },
+        {
+          name: 'size',
+          value: args.size,
+        },
+        {
+          name: 'value',
+          value: args.value,
+        },
+        {
+          name: 'valueClassName',
+          value: valueClassName,
+        },
+        {
+          name: 'valueDisplay',
+          value: args.valueDisplay,
+        },
+        {
+          name: 'valueLabel',
+          value: valueLabel,
+        },
+      ],
+    });
+
     return (
-      <StoryStack>
+      <StoryPlayground>
         <StoryInfoPanel className='text-sm text-[var(--color-text-secondary)]'>
-          CircularProgress supports centered value text as percentage or step fraction.
+          Center value text can be generated as a percent or step fraction, or replaced with{' '}
+          <code>valueLabel</code>.
         </StoryInfoPanel>
-        <div className={getSurfaceClass(args.color)}>
-          <CircularProgress
-            aria-label={ariaLabel}
-            color={args.color}
-            label={label}
-            labelClassName={args.labelClassName || undefined}
-            max={args.max}
-            showValue={args.showValue}
-            size={args.size}
-            value={args.value}
-            valueClassName={args.valueClassName || undefined}
-            valueDisplay={args.valueDisplay}
-            valueLabel={valueLabel}
-          />
-        </div>
-      </StoryStack>
+        <StoryPlaygroundContent split>
+          <StoryPlaygroundPreview>
+            <div className={getSurfaceClass(args.color)}>
+              <CircularProgress
+                aria-label={ariaLabel}
+                color={args.color}
+                label={label}
+                labelClassName={labelClassName}
+                max={args.max}
+                showValue={args.showValue}
+                size={args.size}
+                value={args.value}
+                valueClassName={valueClassName}
+                valueDisplay={args.valueDisplay}
+                valueLabel={valueLabel}
+              />
+            </div>
+          </StoryPlaygroundPreview>
+          <StoryPlaygroundSnippet>
+            <StorybookSourceSnippet code={snippet} />
+          </StoryPlaygroundSnippet>
+        </StoryPlaygroundContent>
+      </StoryPlayground>
     );
   },
 };

--- a/apps/frontend-docs/design-system-react/src/stories/StorybookSourceSnippet.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/StorybookSourceSnippet.tsx
@@ -1,0 +1,71 @@
+import { frontendDocsStoryLayoutClasses } from '@hoite-dev/frontend-docs-shared/storybook';
+import { Source } from '@storybook/addon-docs/blocks';
+import { type ReactElement, useEffect, useState } from 'react';
+import { ensure, ThemeProvider, themes } from 'storybook/theming';
+
+type StorybookSourceSnippetProps = {
+  code: string;
+};
+
+const sourceSnippetThemeClassName = 'frontend-docs-source-snippet';
+const sourceSnippetStyles = `
+.frontend-docs-source-snippet .docblock-source,
+.frontend-docs-source-snippet .docblock-source pre.prismjs {
+  background: var(--color-bg-surface-raised) !important;
+}
+
+.frontend-docs-source-snippet .docblock-source button {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.frontend-docs-source-snippet .docblock-source button::before {
+  background-color: currentColor;
+  content: '';
+  display: inline-block;
+  height: 0.875rem;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M5 1.5h6A1.5 1.5 0 0 1 12.5 3v8A1.5 1.5 0 0 1 11 12.5H5A1.5 1.5 0 0 1 3.5 11V3A1.5 1.5 0 0 1 5 1.5Zm0 1A.5.5 0 0 0 4.5 3v8a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 .5-.5V3a.5.5 0 0 0-.5-.5H5Z'/%3E%3Cpath d='M2 4.5h1v7A1.5 1.5 0 0 0 4.5 13H10v1H4.5A2.5 2.5 0 0 1 2 11.5v-7Z'/%3E%3C/svg%3E") center / contain no-repeat;
+  width: 0.875rem;
+}
+`;
+
+function readPreviewTheme(): 'dark' | 'light' {
+  if (typeof document === 'undefined') {
+    return 'light';
+  }
+
+  return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+}
+
+export function StorybookSourceSnippet({ code }: StorybookSourceSnippetProps): ReactElement {
+  const [previewTheme, setPreviewTheme] = useState(readPreviewTheme);
+  const isDarkTheme = previewTheme === 'dark';
+  const sourceTheme = previewTheme === 'dark' ? themes.dark : themes.light;
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setPreviewTheme(readPreviewTheme());
+    });
+
+    observer.observe(document.documentElement, {
+      attributeFilter: ['data-theme'],
+      attributes: true,
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className={frontendDocsStoryLayoutClasses.snippetPanel}>
+      <ThemeProvider theme={ensure(sourceTheme)}>
+        <div className={sourceSnippetThemeClassName}>
+          <style>{sourceSnippetStyles}</style>
+          <Source code={code} copyable dark={isDarkTheme} language='tsx' />
+        </div>
+      </ThemeProvider>
+    </div>
+  );
+}

--- a/apps/frontend-docs/design-system-react/src/stories/StorybookSourceSnippet.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/StorybookSourceSnippet.tsx
@@ -9,11 +9,6 @@ type StorybookSourceSnippetProps = {
 
 const sourceSnippetThemeClassName = 'frontend-docs-source-snippet';
 const sourceSnippetStyles = `
-.frontend-docs-source-snippet .docblock-source,
-.frontend-docs-source-snippet .docblock-source pre.prismjs {
-  background: var(--color-bg-surface-raised) !important;
-}
-
 .frontend-docs-source-snippet .docblock-source button {
   align-items: center;
   display: inline-flex;

--- a/apps/frontend-docs/design-system-react/src/stories/Typography.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Typography.stories.tsx
@@ -1,7 +1,11 @@
 import {
+  createFrontendDocsComponentSnippet,
   createFrontendDocsPlaygroundParameters,
   StoryInfoPanel,
-  StoryStack,
+  StoryPlayground,
+  StoryPlaygroundContent,
+  StoryPlaygroundPreview,
+  StoryPlaygroundSnippet,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 import {
   resolveTypographyDefaultTag,
@@ -13,6 +17,8 @@ import {
 } from '@hoite-dev/ui';
 import { Typography } from '@hoite-dev/ui-react';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/react-vite';
+
+import { StorybookSourceSnippet } from './StorybookSourceSnippet';
 
 const defaultTagOption = 'Default variant tag';
 const variantKeys = Object.keys(typographyVariantConfig) as TypographyVariant[];
@@ -102,25 +108,49 @@ export const Playground: Story = {
       },
     },
   }),
-  render: (args) => (
-    <StoryStack>
-      <StoryInfoPanel>
-        <p className='m-0 text-sm text-[var(--color-text-primary)]'>
-          Use <code>variant</code>, <code>tag</code>, and text content as the main Typography API.
-          Leave <code>tag</code> on the default option to use the selected variant&apos;s standard
-          HTML element.
-        </p>
-        <p className='mb-0 mt-3 text-sm text-[var(--color-text-secondary)]'>
-          Supported passthrough attributes include <code>id</code>, <code>title</code>,{' '}
-          <code>aria-label</code>, and deliberate <code>data-*</code> attributes on the rendered
-          HTML element.
-        </p>
-      </StoryInfoPanel>
-      <Typography tag={normalizeTag(args.tag)} variant={normalizeVariant(args.variant)}>
-        {args.children}
-      </Typography>
-    </StoryStack>
-  ),
+  render: (args) => {
+    const tag = normalizeTag(args.tag);
+    const variant = normalizeVariant(args.variant);
+    const snippet = createFrontendDocsComponentSnippet({
+      children: args.children,
+      componentName: 'Typography',
+      framework: 'react',
+      props: [
+        {
+          name: 'variant',
+          value: variant,
+        },
+        {
+          name: 'tag',
+          value: tag,
+        },
+      ],
+    });
+
+    return (
+      <StoryPlayground>
+        <StoryInfoPanel>
+          <p className='m-0 text-sm text-[var(--color-text-primary)]'>
+            The default tag follows the selected variant. Supported passthroughs: <code>id</code>,{' '}
+            <code>title</code>, <code>aria-label</code>, and deliberate <code>data-*</code>{' '}
+            attributes.
+          </p>
+        </StoryInfoPanel>
+        <StoryPlaygroundContent split>
+          <StoryPlaygroundPreview>
+            <div className='text-center'>
+              <Typography tag={tag} variant={variant}>
+                {args.children}
+              </Typography>
+            </div>
+          </StoryPlaygroundPreview>
+          <StoryPlaygroundSnippet>
+            <StorybookSourceSnippet code={snippet} />
+          </StoryPlaygroundSnippet>
+        </StoryPlaygroundContent>
+      </StoryPlayground>
+    );
+  },
 };
 
 export const Variants: Story = {

--- a/apps/frontend-docs/design-system-react/src/styles/tailwind.css
+++ b/apps/frontend-docs/design-system-react/src/styles/tailwind.css
@@ -7,8 +7,5 @@
 
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
-@theme {
-  --color-surface-raised: var(--color-bg-surface-raised);
-}
 @source "../../../shared/docs";
 @source "../../../shared/storybook";

--- a/apps/frontend-docs/design-system-react/src/styles/tailwind.css
+++ b/apps/frontend-docs/design-system-react/src/styles/tailwind.css
@@ -7,4 +7,8 @@
 
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
+@theme {
+  --color-surface-raised: var(--color-bg-surface-raised);
+}
 @source "../../../shared/docs";
+@source "../../../shared/storybook";

--- a/apps/frontend-docs/design-system-vue/.storybook/manager.ts
+++ b/apps/frontend-docs/design-system-vue/.storybook/manager.ts
@@ -1,4 +1,15 @@
-import { applyFrontendDocsManagerConfig } from '@hoite-dev/frontend-docs-shared/storybook';
-import { addons } from 'storybook/manager-api';
+import {
+  applyFrontendDocsManagerConfig,
+  registerFrontendDocsPlaygroundCodeTool,
+} from '@hoite-dev/frontend-docs-shared/storybook';
+import * as React from 'react';
+import { Button } from 'storybook/internal/components';
+import { addons, types } from 'storybook/manager-api';
 
 applyFrontendDocsManagerConfig(addons);
+registerFrontendDocsPlaygroundCodeTool({
+  Button,
+  React,
+  addons,
+  types,
+});

--- a/apps/frontend-docs/design-system-vue/.storybook/preview.ts
+++ b/apps/frontend-docs/design-system-vue/.storybook/preview.ts
@@ -7,10 +7,18 @@ import '@hoite-dev/ui/loading.css';
 import '@hoite-dev/ui/typography.css';
 import '../../shared/storybook/hoiteThemePreview.css';
 
-import { frontendDocsPreviewParameters } from '@hoite-dev/frontend-docs-shared/storybook';
+import {
+  frontendDocsPreviewInitialGlobals,
+  frontendDocsPreviewParameters,
+  setupFrontendDocsPlaygroundCodePreview,
+} from '@hoite-dev/frontend-docs-shared/storybook';
 import type { Preview } from '@storybook/vue3-vite';
+import { addons } from 'storybook/preview-api';
+
+setupFrontendDocsPlaygroundCodePreview(addons.getChannel());
 
 const preview: Preview = {
+  initialGlobals: frontendDocsPreviewInitialGlobals,
   parameters: frontendDocsPreviewParameters,
 };
 

--- a/apps/frontend-docs/design-system-vue/package.json
+++ b/apps/frontend-docs/design-system-vue/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear",
-    "predev": "node ../shared/storybook/prepareStorybook.mjs",
+    "prebuild": "node ../shared/storybook/prepareStorybook.mjs",
+    "predev": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear",
     "build": "storybook build",
     "dev": "storybook dev --host design-system-vue.local.hoite.dev --port 6008 --https --ssl-cert ../../../ssl/local.hoite.dev.pem --ssl-key ../../../ssl/local.hoite.dev-key.pem",
     "format": "biome check --write .storybook src package.json tsconfig.json README.md",

--- a/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
@@ -1,6 +1,12 @@
 import {
+  copyFrontendDocsSnippetToClipboard,
+  createFrontendDocsComponentSnippet,
+  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
-  withStoryStack,
+  createVueStoryPreview,
+  createVueStorySourcePanel,
+  withStoryPlayground,
+  withVueStoryPlaygroundContent,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 import {
   type IconName,
@@ -15,7 +21,7 @@ import {
 } from '@hoite-dev/ui';
 import { Icon } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 
 type IconStoryArgs = {
   name: IconName;
@@ -110,33 +116,72 @@ const IconPlaygroundPreview = defineComponent({
       variant: props.variant,
     }));
     const surfaceClass = computed(() => getSurfaceClass(props.variant));
+    const snippet = computed(() =>
+      createFrontendDocsComponentSnippet({
+        componentName: 'Icon',
+        framework: 'vue',
+        props: [
+          {
+            name: 'label',
+            value: 'Playground icon',
+          },
+          {
+            name: 'name',
+            value: props.name,
+          },
+          {
+            name: 'rotation',
+            value: props.rotation,
+          },
+          {
+            name: 'size',
+            value: props.size,
+          },
+          {
+            name: 'variant',
+            value: props.variant,
+          },
+        ],
+      }),
+    );
+    const copyButtonLabel = ref('Copy code');
+    const copySnippet = async () => {
+      copyButtonLabel.value = 'Copying';
+      copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
+        ? 'Copied'
+        : 'Copy error';
+    };
+    const highlightedSnippet = computed(() =>
+      createFrontendDocsHighlightedSnippetHtml(snippet.value),
+    );
 
     return {
+      copyButtonLabel,
+      copySnippet,
+      highlightedSnippet,
       iconArgs,
+      snippet,
       surfaceClass,
     };
   },
-  template: withStoryStack(`
+  template: withStoryPlayground(`
       <div
-        class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4"
+        class="rounded-lg border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4"
       >
         <p class="m-0 text-sm text-[var(--color-text-primary)]">
-          Use <code>name</code>, <code>size</code>, <code>rotation</code>, and
-          <code>variant</code> as the main visual Icon API.
-        </p>
-        <p class="mb-0 mt-3 text-sm text-[var(--color-text-secondary)]">
-          In app code, meaningful icons should also receive an accessible name with
-          <code>label</code> or <code>aria-label</code>.
-        </p>
-        <p class="mb-0 mt-3 text-sm text-[var(--color-text-secondary)]">
-          Supported passthrough attributes stay narrow: <code>id</code>, <code>title</code>,
-          <code>role</code>, <code>aria-label</code>, and deliberate <code>data-*</code>
-          attributes on the rendered SVG.
+          Meaningful icons need <code>label</code> or <code>aria-label</code>. Supported
+          passthroughs: <code>id</code>, <code>title</code>, <code>role</code>,
+          <code>aria-label</code>, and deliberate <code>data-*</code> attributes.
         </p>
       </div>
-      <div :class="surfaceClass">
-        <Icon v-bind="iconArgs" label="Playground icon" />
-      </div>
+      ${withVueStoryPlaygroundContent(`
+        ${createVueStoryPreview(`
+          <div :class="surfaceClass">
+            <Icon v-bind="iconArgs" label="Playground icon" />
+          </div>
+        `)}
+        ${createVueStorySourcePanel()}
+      `)}
   `),
 });
 
@@ -195,7 +240,7 @@ export const Playground: Story = {
         args: computed(() => normalizeIconArgs(args)),
       };
     },
-    template: `<IconPlaygroundPreview v-bind="args" />`,
+    template: '<IconPlaygroundPreview v-bind="args" />',
   }),
 };
 

--- a/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
@@ -45,6 +45,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     table: {
       category: 'Component API',
     },
+    type: {
+      name: 'string',
+    },
   },
   size: {
     control: 'select',
@@ -52,6 +55,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     options: supportedIconSizes,
     table: {
       category: 'Component API',
+    },
+    type: {
+      name: 'string',
     },
   },
   rotation: {
@@ -61,6 +67,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     table: {
       category: 'Component API',
     },
+    type: {
+      name: 'string',
+    },
   },
   variant: {
     control: 'select',
@@ -68,6 +77,9 @@ const storyArgTypes: Partial<ArgTypes<IconStoryArgs>> = {
     options: supportedIconVariants,
     table: {
       category: 'Component API',
+    },
+    type: {
+      name: 'string',
     },
   },
 };

--- a/apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts
@@ -1,6 +1,13 @@
 import {
+  copyFrontendDocsSnippetToClipboard,
+  createFrontendDocsComponentSnippet,
+  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
+  createVueStoryPreview,
+  createVueStorySourcePanel,
+  withStoryPlayground,
   withStoryStack,
+  withVueStoryPlaygroundContent,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 import {
   type LoadingColor,
@@ -11,7 +18,7 @@ import {
 } from '@hoite-dev/ui';
 import { CircularProgress, Loader, Progress } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { computed, defineComponent } from 'vue';
+import { type ComputedRef, computed, defineComponent, ref } from 'vue';
 
 type CircularValueDisplay = 'fraction' | 'percent';
 
@@ -29,6 +36,25 @@ type LoadingStoryArgs = {
   value: number;
   valueDisplay: CircularValueDisplay;
 };
+
+function createSnippetCopyState(snippet: ComputedRef<string>) {
+  const copyButtonLabel = ref('Copy code');
+  const highlightedSnippet = computed(() =>
+    createFrontendDocsHighlightedSnippetHtml(snippet.value),
+  );
+  const copySnippet = async () => {
+    copyButtonLabel.value = 'Copying';
+    copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
+      ? 'Copied'
+      : 'Copy error';
+  };
+
+  return {
+    copyButtonLabel,
+    copySnippet,
+    highlightedSnippet,
+  };
+}
 
 const storyArgTypes: Partial<ArgTypes<LoadingStoryArgs>> = {
   size: {
@@ -146,19 +172,49 @@ const LoaderPlaygroundPreview = defineComponent({
       return undefined;
     });
     const surfaceClass = computed(() => getSurfaceClass(props.color));
+    const snippet = computed(() =>
+      createFrontendDocsComponentSnippet({
+        componentName: 'Loader',
+        framework: 'vue',
+        props: [
+          {
+            name: 'aria-label',
+            value: normalizedAriaLabel.value,
+          },
+          {
+            name: 'color',
+            value: props.color,
+          },
+          {
+            name: 'size',
+            value: props.size,
+          },
+        ],
+      }),
+    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createSnippetCopyState(snippet);
 
     return {
+      copyButtonLabel,
+      copySnippet,
+      highlightedSnippet,
       normalizedAriaLabel,
+      snippet,
       surfaceClass,
     };
   },
-  template: withStoryStack(`
-      <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
-        Loader uses <code>aria-label</code> or <code>aria-labelledby</code> when it is not decorative.
+  template: withStoryPlayground(`
+      <div class="rounded-lg border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
+        Use <code>aria-label</code> or <code>aria-labelledby</code> when no visible label is present.
       </div>
-      <div :class="surfaceClass">
-        <Loader :aria-label="normalizedAriaLabel" :color="color" :size="size" />
-      </div>
+      ${withVueStoryPlaygroundContent(`
+        ${createVueStoryPreview(`
+          <div :class="surfaceClass">
+            <Loader :aria-label="normalizedAriaLabel" :color="color" :size="size" />
+          </div>
+        `)}
+        ${createVueStorySourcePanel()}
+      `)}
   `),
 });
 
@@ -221,28 +277,73 @@ const ProgressPlaygroundPreview = defineComponent({
       return props.value;
     });
     const surfaceClass = computed(() => getSurfaceClass(props.color));
+    const snippet = computed(() =>
+      createFrontendDocsComponentSnippet({
+        componentName: 'Progress',
+        framework: 'vue',
+        props: [
+          {
+            name: 'aria-label',
+            value: normalizedAriaLabel.value,
+          },
+          {
+            name: 'color',
+            value: props.color,
+          },
+          {
+            name: 'label',
+            value: normalizedLabel.value,
+          },
+          {
+            name: 'max',
+            value: props.max,
+          },
+          {
+            name: 'size',
+            value: props.size,
+          },
+          {
+            name: 'value',
+            value: normalizedValue.value,
+          },
+        ],
+      }),
+    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createSnippetCopyState(snippet);
 
     return {
+      copyButtonLabel,
+      copySnippet,
+      highlightedSnippet,
       normalizedAriaLabel,
       normalizedLabel,
       normalizedValue,
+      snippet,
       surfaceClass,
     };
   },
-  template: withStoryStack(`
-      <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
-        Progress uses native <code>&lt;progress&gt;</code> semantics with shared numeric normalization.
+  template: withStoryPlayground(`
+      <div class="rounded-lg border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
+        Indeterminate progress omits <code>value</code>; otherwise value is normalized against <code>max</code>.
       </div>
-      <div :class="surfaceClass">
-        <Progress
-          :aria-label="normalizedAriaLabel"
-          :color="color"
-          :label="normalizedLabel"
-          :max="max"
-          :size="size"
-          :value="normalizedValue"
-        />
-      </div>
+      ${withVueStoryPlaygroundContent(`
+        ${createVueStoryPreview(
+          `
+          <div :class="[surfaceClass, 'box-border w-full [&_.progress-field]:w-full']">
+            <Progress
+              :aria-label="normalizedAriaLabel"
+              :color="color"
+              :label="normalizedLabel"
+              :max="max"
+              :size="size"
+              :value="normalizedValue"
+            />
+          </div>
+        `,
+          'min-w-0 w-full',
+        )}
+        ${createVueStorySourcePanel()}
+      `)}
   `),
 });
 
@@ -317,33 +418,96 @@ const CircularProgressPlaygroundPreview = defineComponent({
       return undefined;
     });
     const surfaceClass = computed(() => getSurfaceClass(props.color));
+    const snippet = computed(() =>
+      createFrontendDocsComponentSnippet({
+        componentName: 'CircularProgress',
+        framework: 'vue',
+        props: [
+          {
+            name: 'aria-label',
+            value: normalizedAriaLabel.value,
+          },
+          {
+            name: 'color',
+            value: props.color,
+          },
+          {
+            name: 'label',
+            value: normalizedLabel.value,
+          },
+          {
+            name: 'label-class',
+            value: props.labelClass,
+          },
+          {
+            name: 'max',
+            value: props.max,
+          },
+          {
+            defaultValue: true,
+            name: 'show-value',
+            value: props.showValue,
+          },
+          {
+            name: 'size',
+            value: props.size,
+          },
+          {
+            name: 'value',
+            value: props.value,
+          },
+          {
+            name: 'value-class',
+            value: props.valueClass,
+          },
+          {
+            name: 'value-display',
+            value: props.valueDisplay,
+          },
+          {
+            name: 'value-label',
+            value: normalizedValueLabel.value,
+          },
+        ],
+      }),
+    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createSnippetCopyState(snippet);
 
     return {
+      copyButtonLabel,
+      copySnippet,
+      highlightedSnippet,
       normalizedAriaLabel,
       normalizedLabel,
       normalizedValueLabel,
+      snippet,
       surfaceClass,
     };
   },
-  template: withStoryStack(`
-      <div class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
-        CircularProgress supports centered value text as percentage or step fraction.
+  template: withStoryPlayground(`
+      <div class="rounded-lg border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4 text-sm text-[var(--color-text-secondary)]">
+        Center value text can be generated as a percent or step fraction, or replaced with <code>valueLabel</code>.
       </div>
-      <div :class="surfaceClass">
-        <CircularProgress
-          :aria-label="normalizedAriaLabel"
-          :color="color"
-          :label="normalizedLabel"
-          :label-class="labelClass || undefined"
-          :max="max"
-          :show-value="showValue"
-          :size="size"
-          :value="value"
-          :value-class="valueClass || undefined"
-          :value-display="valueDisplay"
-          :value-label="normalizedValueLabel"
-        />
-      </div>
+      ${withVueStoryPlaygroundContent(`
+        ${createVueStoryPreview(`
+          <div :class="surfaceClass">
+            <CircularProgress
+              :aria-label="normalizedAriaLabel"
+              :color="color"
+              :label="normalizedLabel"
+              :label-class="labelClass || undefined"
+              :max="max"
+              :show-value="showValue"
+              :size="size"
+              :value="value"
+              :value-class="valueClass || undefined"
+              :value-display="valueDisplay"
+              :value-label="normalizedValueLabel"
+            />
+          </div>
+        `)}
+        ${createVueStorySourcePanel()}
+      `)}
   `),
 });
 

--- a/apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts
@@ -1,6 +1,12 @@
 import {
+  copyFrontendDocsSnippetToClipboard,
+  createFrontendDocsComponentSnippet,
+  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
-  withStoryStack,
+  createVueStoryPreview,
+  createVueStorySourcePanel,
+  withStoryPlayground,
+  withVueStoryPlaygroundContent,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 import {
   supportedTypographyTags,
@@ -11,7 +17,7 @@ import {
 } from '@hoite-dev/ui';
 import { Typography } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 const defaultTagOption = 'Default variant tag';
 const variantKeys = Object.keys(typographyVariantConfig) as TypographyVariant[];
@@ -89,31 +95,65 @@ export const Playground: Story = {
     components: { Typography },
     setup() {
       const normalizedVariant = computed(() => normalizeVariant(args.variant));
+      const normalizedTag = computed(() => normalizeTag(args.tag));
+      const snippet = computed(() =>
+        createFrontendDocsComponentSnippet({
+          children: args.children,
+          componentName: 'Typography',
+          framework: 'vue',
+          props: [
+            {
+              name: 'variant',
+              value: normalizedVariant.value,
+            },
+            {
+              name: 'tag',
+              value: normalizedTag.value,
+            },
+          ],
+        }),
+      );
+      const copyButtonLabel = ref('Copy code');
+      const copySnippet = async () => {
+        copyButtonLabel.value = 'Copying';
+        copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
+          ? 'Copied'
+          : 'Copy error';
+      };
+      const highlightedSnippet = computed(() =>
+        createFrontendDocsHighlightedSnippetHtml(snippet.value),
+      );
 
       return {
         args,
-        normalizedTag: computed(() => normalizeTag(args.tag)),
+        copyButtonLabel,
+        copySnippet,
+        highlightedSnippet,
+        normalizedTag,
         normalizedVariant,
+        snippet,
       };
     },
-    template: withStoryStack(`
+    template: withStoryPlayground(`
         <div
-          class="rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4"
+          class="rounded-lg border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4"
         >
           <p class="m-0 text-sm text-[var(--color-text-primary)]">
-            Use <code>variant</code>, <code>tag</code>, and text content as the main Typography API.
-            Leave <code>tag</code> on the default option to use the selected variant's standard HTML
-            element.
-          </p>
-          <p class="mb-0 mt-3 text-sm text-[var(--color-text-secondary)]">
-            Supported passthrough attributes include <code>id</code>, <code>title</code>,
-            <code>aria-label</code>, and deliberate <code>data-*</code> attributes on the rendered
-            HTML element.
+            The default tag follows the selected variant. Supported passthroughs: <code>id</code>,
+            <code>title</code>, <code>aria-label</code>, and deliberate <code>data-*</code>
+            attributes.
           </p>
         </div>
-        <Typography :tag="normalizedTag" :variant="normalizedVariant">
-          {{ args.children }}
-        </Typography>
+        ${withVueStoryPlaygroundContent(`
+          ${createVueStoryPreview(`
+            <div class="text-center">
+              <Typography :tag="normalizedTag" :variant="normalizedVariant">
+                {{ args.children }}
+              </Typography>
+            </div>
+          `)}
+          ${createVueStorySourcePanel()}
+        `)}
     `),
   }),
 };

--- a/apps/frontend-docs/design-system-vue/src/styles/tailwind.css
+++ b/apps/frontend-docs/design-system-vue/src/styles/tailwind.css
@@ -7,8 +7,5 @@
 
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
-@theme {
-  --color-surface-raised: var(--color-bg-surface-raised);
-}
 @source "../../../shared/docs";
 @source "../../../shared/storybook";

--- a/apps/frontend-docs/design-system-vue/src/styles/tailwind.css
+++ b/apps/frontend-docs/design-system-vue/src/styles/tailwind.css
@@ -7,4 +7,8 @@
 
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
+@theme {
+  --color-surface-raised: var(--color-bg-surface-raised);
+}
 @source "../../../shared/docs";
+@source "../../../shared/storybook";

--- a/apps/frontend-docs/hub/.storybook/manager.ts
+++ b/apps/frontend-docs/hub/.storybook/manager.ts
@@ -6,9 +6,12 @@ import {
   createHoiteStorybookThemeOptions,
   frontendDocsManagerConfig,
   type HoiteStorybookThemeName,
+  registerFrontendDocsPlaygroundCodeTool,
 } from '@hoite-dev/frontend-docs-shared/storybook';
 
-import { addons, type State } from 'storybook/manager-api';
+import * as React from 'react';
+import { Button } from 'storybook/internal/components';
+import { addons, type State, types } from 'storybook/manager-api';
 import { create } from 'storybook/theming';
 import { registerStorybookCompositionPreviewFrameWorkaround } from './storybookCompositionPreviewFrameWorkaround.ts';
 
@@ -45,7 +48,7 @@ function applyCurrentStorybookTheme(): void {
       },
       showToolbar(state: State, defaultValue: boolean) {
         if (isContractDocsStory(state)) {
-          return false;
+          return true;
         }
 
         return defaultValue;
@@ -77,3 +80,9 @@ function observeThemeChanges(): void {
 applyCurrentStorybookTheme();
 observeThemeChanges();
 registerStorybookCompositionPreviewFrameWorkaround();
+registerFrontendDocsPlaygroundCodeTool({
+  Button,
+  React,
+  addons,
+  types,
+});

--- a/apps/frontend-docs/hub/.storybook/preview.ts
+++ b/apps/frontend-docs/hub/.storybook/preview.ts
@@ -7,8 +7,14 @@ import '@hoite-dev/ui/loading.css';
 import '@hoite-dev/ui/typography.css';
 import '../../shared/storybook/hoiteThemePreview.css';
 
-import { frontendDocsPreviewParameters } from '@hoite-dev/frontend-docs-shared/storybook';
+import {
+  frontendDocsPreviewParameters,
+  setupFrontendDocsPlaygroundCodePreview,
+} from '@hoite-dev/frontend-docs-shared/storybook';
 import type { Preview } from '@storybook/react-vite';
+import { addons } from 'storybook/preview-api';
+
+setupFrontendDocsPlaygroundCodePreview(addons.getChannel());
 
 const preview: Preview = {
   parameters: frontendDocsPreviewParameters,

--- a/apps/frontend-docs/hub/.storybook/storybookCompositionPreviewFrameWorkaround.ts
+++ b/apps/frontend-docs/hub/.storybook/storybookCompositionPreviewFrameWorkaround.ts
@@ -7,6 +7,8 @@ import { addons } from 'storybook/manager-api';
  * `storybook-preview-iframe` with that ref's iframe URL. That creates two ref iframes with the same
  * source URL, which can leave ref addon panels such as Controls empty. Returning to a local hub story
  * then asks the ref runtime to render the local story id, leaving the preview in a broken state.
+ * It can also clear initial URL args before the composed ref iframe has applied them, so initial
+ * ref args are replayed once through the manager API after the ref story is prepared.
  *
  * Re-check this after Storybook upgrades and remove it once local stories correctly restore the
  * local `/iframe.html` preview after refresh-on-ref navigation without this guard.
@@ -15,6 +17,33 @@ const WORKAROUND_ADDON_ID =
   '@hoite-dev/frontend-docs-hub/storybook-composition-preview-frame-workaround';
 const MAIN_PREVIEW_IFRAME_ID = 'storybook-preview-iframe';
 const IDLE_PREVIEW_IFRAME_HREF = 'iframe.html?id=*&viewMode=story';
+const STORYBOOK_CURRENT_STORY_WAS_SET_EVENT = 'currentStoryWasSet';
+const STORYBOOK_STORY_PREPARED_EVENT = 'storyPrepared';
+const serializedNumberPattern = /^-?[0-9]+(\.[0-9]+)?$/;
+
+const initialSearchParams = new URLSearchParams(window.location.search);
+const initialComposedRefArgs = initialSearchParams.get('args');
+const initialComposedRefPath = initialSearchParams.get('path');
+
+let pendingInitialComposedRefArgs =
+  initialComposedRefArgs && initialComposedRefPath
+    ? {
+        args: initialComposedRefArgs,
+        path: initialComposedRefPath,
+      }
+    : null;
+
+type StorybookArgType = {
+  type?: {
+    name?: string;
+  };
+};
+
+type StorybookPreparedStory = {
+  argTypes?: Record<string, StorybookArgType>;
+  id: string;
+  refId?: string;
+};
 
 function toAbsoluteHref(href: string): string {
   return new URL(href, window.location.href).href;
@@ -24,6 +53,10 @@ function getIframeHref(iframe: HTMLIFrameElement): string {
   const src = iframe.getAttribute('src') ?? iframe.src;
 
   return toAbsoluteHref(src);
+}
+
+function getCurrentPathParam(): string | null {
+  return new URLSearchParams(window.location.search).get('path');
 }
 
 function isComposedRefPreviewFrame(api: API, iframe: HTMLIFrameElement): boolean {
@@ -37,7 +70,7 @@ function isComposedRefPreviewFrame(api: API, iframe: HTMLIFrameElement): boolean
 }
 
 function getActiveRefId(api: API): string | null {
-  const path = new URLSearchParams(window.location.search).get('path');
+  const path = getCurrentPathParam();
 
   if (path) {
     const urlRefId = Object.keys(api.getRefs()).find((refId) => {
@@ -60,6 +93,109 @@ function getActiveRefId(api: API): string | null {
       return storyId.startsWith(`${refId}_`);
     }) ?? null
   );
+}
+
+function getInitialComposedRefArgsForCurrentPath(): string | null {
+  const currentPath = getCurrentPathParam();
+
+  if (!pendingInitialComposedRefArgs || currentPath !== pendingInitialComposedRefArgs.path) {
+    return null;
+  }
+
+  return pendingInitialComposedRefArgs.args;
+}
+
+function deserializeStorybookUrlArgValue(value: string): unknown {
+  if (value === '!undefined') {
+    return undefined;
+  }
+
+  if (value === '!null') {
+    return null;
+  }
+
+  if (value === '!true') {
+    return true;
+  }
+
+  if (value === '!false') {
+    return false;
+  }
+
+  if (serializedNumberPattern.test(value)) {
+    return Number(value);
+  }
+
+  return value;
+}
+
+function coerceStorybookUrlArgValue(
+  value: unknown,
+  argType: StorybookArgType | undefined,
+): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (argType?.type?.name === 'string') {
+    return String(value);
+  }
+
+  if (argType?.type?.name === 'number') {
+    return Number(value);
+  }
+
+  if (argType?.type?.name === 'boolean') {
+    return value === true || String(value) === 'true';
+  }
+
+  return value;
+}
+
+function parseStorybookUrlArgs(
+  serializedArgs: string,
+  argTypes: Record<string, StorybookArgType>,
+): Record<string, unknown> {
+  return serializedArgs.split(';').reduce<Record<string, unknown>>((args, pair) => {
+    const separatorIndex = pair.indexOf(':');
+
+    if (separatorIndex <= 0) {
+      return args;
+    }
+
+    const name = pair.slice(0, separatorIndex);
+    const rawValue = pair.slice(separatorIndex + 1);
+    const value = deserializeStorybookUrlArgValue(rawValue);
+
+    args[name] = coerceStorybookUrlArgValue(value, argTypes[name]);
+    return args;
+  }, {});
+}
+
+function reconcileInitialComposedRefArgs(api: API): void {
+  const activeRefId = getActiveRefId(api);
+
+  if (activeRefId === null) {
+    return;
+  }
+
+  const args = getInitialComposedRefArgsForCurrentPath();
+
+  if (!args) {
+    return;
+  }
+
+  const currentStory = api.getCurrentStoryData() as StorybookPreparedStory | undefined;
+
+  if (!currentStory || currentStory.refId !== activeRefId || !currentStory.argTypes) {
+    return;
+  }
+
+  api.updateStoryArgs(
+    currentStory as Parameters<API['updateStoryArgs']>[0],
+    parseStorybookUrlArgs(args, currentStory.argTypes),
+  );
+  pendingInitialComposedRefArgs = null;
 }
 
 function setPreviewIframeHref(iframe: HTMLIFrameElement, href: string): void {
@@ -108,6 +244,11 @@ function reconcileMainPreviewFrameIdentity(api: API): void {
   setPreviewIframeHref(previewIframe, previewHref);
 }
 
+function reconcileCompositionPreviewFrames(api: API): void {
+  reconcileMainPreviewFrameIdentity(api);
+  reconcileInitialComposedRefArgs(api);
+}
+
 function createReconciliationScheduler(api: API): () => void {
   let scheduledFrameId: number | null = null;
 
@@ -118,7 +259,7 @@ function createReconciliationScheduler(api: API): () => void {
 
     scheduledFrameId = window.requestAnimationFrame(() => {
       scheduledFrameId = null;
-      reconcileMainPreviewFrameIdentity(api);
+      reconcileCompositionPreviewFrames(api);
     });
   };
 }
@@ -155,6 +296,8 @@ export function registerStorybookCompositionPreviewFrameWorkaround(): void {
     window.addEventListener('popstate', () => {
       scheduleReconciliation();
     });
+    api.on(STORYBOOK_CURRENT_STORY_WAS_SET_EVENT, scheduleReconciliation);
+    api.on(STORYBOOK_STORY_PREPARED_EVENT, scheduleReconciliation);
 
     scheduleReconciliation();
   });

--- a/apps/frontend-docs/hub/README.md
+++ b/apps/frontend-docs/hub/README.md
@@ -51,6 +51,12 @@ The `site-nuxt-components` Storybook remains available as a separate app-specifi
 
 In normal local development, the referenced Storybooks run side by side instead of being composed automatically. The preferred deployed model remains one unified public frontend docs experience, with the hub at `/` and same-domain refs such as `/refs/react/` and `/refs/vue/`.
 
+## Storybook workarounds
+
+The hub registers temporary Storybook 10.4.0 composition guards in `.storybook/storybookCompositionPreviewFrameWorkaround.ts`.
+
+The frontend docs workspace README describes the known composition issues. Keep the implementation hub-local and re-check it after Storybook upgrades.
+
 ## Production container
 
 `apps/frontend-docs/hub` is the canonical production frontend docs deploy target.

--- a/apps/frontend-docs/hub/package.json
+++ b/apps/frontend-docs/hub/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "sync:brand-assets": "node ./scripts/sync-brand-assets.mjs",
-    "prebuild": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear --sync-brand-assets",
-    "predev": "node ../shared/storybook/prepareStorybook.mjs --sync-brand-assets",
+    "prebuild": "node ../shared/storybook/prepareStorybook.mjs --sync-brand-assets",
+    "predev": "node ../shared/storybook/prepareStorybook.mjs --sync-brand-assets --skip-cache-clear",
     "build": "storybook build",
     "dev": "storybook dev --host frontend-docs.local.hoite.dev --port 6006 --https --ssl-cert ../../../ssl/local.hoite.dev.pem --ssl-key ../../../ssl/local.hoite.dev-key.pem",
     "format": "biome check --write .storybook src scripts package.json tsconfig.json README.md",

--- a/apps/frontend-docs/hub/src/stories/IconOverview.stories.tsx
+++ b/apps/frontend-docs/hub/src/stories/IconOverview.stories.tsx
@@ -130,6 +130,15 @@ export const Icon: Story = {
             stroke width of <code> 2 </code>, and round line caps and joins across every icon.
           </p>
         </ContractSection>
+        <ContractSection title='Attribution'>
+          <p className='m-0 text-sm text-[var(--color-text-secondary)]'>
+            Icon SVG path data is derived from{' '}
+            <a href='https://github.com/tabler/tabler-icons' rel='noreferrer' target='_blank'>
+              Tabler Icons
+            </a>
+            , which is licensed under the MIT License.
+          </p>
+        </ContractSection>
         <ContractSection title='Accessibility contract'>
           <p className='m-0 text-sm text-[var(--color-text-secondary)]'>
             Icons without <code>label</code> or <code>aria-label</code> are decorative and hidden

--- a/apps/frontend-docs/shared/docs/FrameworkComponentDocsPage.tsx
+++ b/apps/frontend-docs/shared/docs/FrameworkComponentDocsPage.tsx
@@ -10,6 +10,8 @@ type StoryReference = {
   storyName?: string;
 };
 
+type CanvasSourceState = 'hidden' | 'shown' | 'none';
+
 type ControlSection = {
   story: StoryReference;
   title?: string;
@@ -17,7 +19,8 @@ type ControlSection = {
 
 type FrameworkComponentDocsPageProps = {
   argTypesBlock: ElementType<{ of: unknown }>;
-  canvasBlock: ElementType<{ of: unknown }>;
+  canvasBlock: ElementType<{ of: unknown; sourceState?: CanvasSourceState }>;
+  canvasSourceState?: CanvasSourceState;
   contractSourceLinks: readonly SourceLink[];
   controls: readonly ControlSection[];
   docs: ComponentDocs;
@@ -59,8 +62,9 @@ function renderControls(
 }
 
 function renderExamples(
-  CanvasBlock: ElementType<{ of: unknown }>,
+  CanvasBlock: FrameworkComponentDocsPageProps['canvasBlock'],
   examples: readonly StoryReference[],
+  sourceState: CanvasSourceState,
 ): ReactNode {
   return createElement(
     Fragment,
@@ -72,7 +76,7 @@ function renderExamples(
           key: `example-${index}`,
           story,
         },
-        createElement(CanvasBlock, { of: story }),
+        createElement(CanvasBlock, { of: story, sourceState }),
       ),
     ),
   );
@@ -81,6 +85,7 @@ function renderExamples(
 export function FrameworkComponentDocsPage({
   argTypesBlock: ArgTypesBlock,
   canvasBlock: CanvasBlock,
+  canvasSourceState = 'none',
   contractSourceLinks,
   controls,
   docs,
@@ -92,7 +97,7 @@ export function FrameworkComponentDocsPage({
   return createElement(DesignSystemDocsPage, {
     controls: renderControls(ArgTypesBlock, controls),
     docs,
-    examples: renderExamples(CanvasBlock, examples),
+    examples: renderExamples(CanvasBlock, examples, canvasSourceState),
     sourceLinks: [
       ...contractSourceLinks,
       ...createFrameworkSourceLinks(framework, implementationPath, storiesPath),

--- a/apps/frontend-docs/shared/docs/inlineBbCode.tsx
+++ b/apps/frontend-docs/shared/docs/inlineBbCode.tsx
@@ -1,0 +1,68 @@
+import { createElement, type ReactNode } from 'react';
+
+const inlineBbCodeTagNames = ['code', 'url'] as const;
+const inlineBbCodeTagPattern = new RegExp(
+  `\\[(${inlineBbCodeTagNames.join('|')})(?:=([^\\]]+))?\\]([\\s\\S]*?)\\[/\\1\\]`,
+  'g',
+);
+
+type InlineBbCodeTagName = (typeof inlineBbCodeTagNames)[number];
+
+type InlineBbCodeRenderer = (
+  content: string,
+  attribute: string | undefined,
+  key: string,
+) => ReactNode;
+
+const inlineBbCodeRenderers = {
+  code: (content, _attribute, key) => createElement('code', { key }, content),
+  url: (content, attribute, key) => {
+    if (!attribute) {
+      return content;
+    }
+
+    return createElement(
+      'a',
+      {
+        href: attribute,
+        key,
+        rel: 'noreferrer',
+        target: '_blank',
+      },
+      content,
+    );
+  },
+} satisfies Record<InlineBbCodeTagName, InlineBbCodeRenderer>;
+
+export function renderInlineBbCode(text: string): ReactNode {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(inlineBbCodeTagPattern)) {
+    const [rawMatch, tagName, attribute, content] = match;
+    const matchIndex = match.index;
+
+    if (matchIndex > lastIndex) {
+      nodes.push(text.slice(lastIndex, matchIndex));
+    }
+
+    nodes.push(
+      inlineBbCodeRenderers[tagName as InlineBbCodeTagName](
+        content,
+        attribute,
+        `${text}-${matchIndex}`,
+      ),
+    );
+    lastIndex = matchIndex + rawMatch.length;
+  }
+
+  if (nodes.length === 0) {
+    return text;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
+}

--- a/apps/frontend-docs/shared/docs/renderDocsSections.tsx
+++ b/apps/frontend-docs/shared/docs/renderDocsSections.tsx
@@ -1,8 +1,10 @@
 import { createElement, type ReactNode } from 'react';
 
 import type { DocsSection } from './docsTypes';
+import { renderInlineBbCode } from './inlineBbCode';
 
 const sectionClassName = 'grid gap-4';
+const paragraphClassName = 'm-0';
 const listClassName = '!m-0 grid !pl-5';
 
 function renderParagraphs(paragraphs: readonly string[] | undefined): ReactNode[] {
@@ -10,7 +12,13 @@ function renderParagraphs(paragraphs: readonly string[] | undefined): ReactNode[
     return [];
   }
 
-  return paragraphs.map((paragraph) => createElement('p', { key: paragraph }, paragraph));
+  return paragraphs.map((paragraph) =>
+    createElement(
+      'p',
+      { className: paragraphClassName, key: paragraph },
+      renderInlineBbCode(paragraph),
+    ),
+  );
 }
 
 function renderItems(items: readonly string[] | undefined): ReactNode | null {
@@ -24,7 +32,7 @@ function renderItems(items: readonly string[] | undefined): ReactNode | null {
       className: listClassName,
       key: 'items',
     },
-    items.map((item) => createElement('li', { key: item }, item)),
+    items.map((item) => createElement('li', { key: item }, renderInlineBbCode(item))),
   );
 }
 

--- a/apps/frontend-docs/shared/storybook/compositionThemeConfig.ts
+++ b/apps/frontend-docs/shared/storybook/compositionThemeConfig.ts
@@ -17,5 +17,6 @@ export const compositionThemeConfig = defineCompositionThemeConfig({
   toolbar: {
     control: 'toggle',
     label: 'Theme',
+    title: 'Theme: Switch global theme',
   },
 });

--- a/apps/frontend-docs/shared/storybook/config.ts
+++ b/apps/frontend-docs/shared/storybook/config.ts
@@ -1,5 +1,10 @@
 export const frontendDocsCoreConfig = {
+  disableWhatsNewNotifications: true,
   allowedHosts: true,
+} as const;
+
+export const frontendDocsParametersConfig = {
+  actions: { disable: true },
 } as const;
 
 export const frontendDocsDefaultAddons = [
@@ -59,11 +64,11 @@ export function createFrontendDocsAddons(
   compositionThemeOptions: unknown,
 ): readonly FrontendDocsAddon[] {
   return [
-    ...frontendDocsDefaultAddons,
     {
       name: '@hoite-dev/storybook-addon-composition-theme',
       options: compositionThemeOptions,
     },
+    ...frontendDocsDefaultAddons,
   ];
 }
 
@@ -128,6 +133,7 @@ export function createFrontendDocsStorybookConfig<TConfig>({
   return {
     addons: [...addons],
     core: frontendDocsCoreConfig,
+    parameters: frontendDocsParametersConfig,
     framework: {
       name: frameworkName,
       options: {},

--- a/apps/frontend-docs/shared/storybook/hoiteThemeManager.css
+++ b/apps/frontend-docs/shared/storybook/hoiteThemeManager.css
@@ -74,6 +74,17 @@ section.sb-bar {
   color: var(--color-text-secondary);
 }
 
+section.sb-bar #composition-theme-tool,
+section.sb-bar button[aria-label="Switch global theme"],
+section.sb-bar button[aria-label="Theme: Switch global theme"] {
+  order: -20;
+}
+
+section.sb-bar #frontend-docs-playground-code-tool,
+section.sb-bar button[aria-label="Snippets: Show code snippets in playgrounds for easy copy"] {
+  order: -10;
+}
+
 .hoite-storybook-brand {
   align-items: center;
   color: var(--color-text-primary);

--- a/apps/frontend-docs/shared/storybook/hoiteThemePreview.css
+++ b/apps/frontend-docs/shared/storybook/hoiteThemePreview.css
@@ -1,13 +1,5 @@
 html,
 body,
-#storybook-root,
-#root,
-#storybook-docs {
-  min-height: 100vh;
-}
-
-html,
-body,
 .sb-show-main,
 #storybook-root,
 #root,
@@ -66,6 +58,53 @@ body,
 #root {
   color: inherit;
   font-family: inherit;
+}
+
+:root {
+  --frontend-docs-snippet-token-attribute: #d73a49;
+  --frontend-docs-snippet-token-literal: #005cc5;
+  --frontend-docs-snippet-token-string: #6f42c1;
+  --frontend-docs-snippet-token-tag: #22863a;
+}
+
+:root[data-theme="dark"] {
+  --frontend-docs-snippet-token-attribute: #ff7b72;
+  --frontend-docs-snippet-token-literal: #79c0ff;
+  --frontend-docs-snippet-token-string: #d2a8ff;
+  --frontend-docs-snippet-token-tag: #7ee787;
+}
+
+.frontend-docs-snippet-token-attribute {
+  color: var(--frontend-docs-snippet-token-attribute);
+}
+
+.frontend-docs-snippet-token-literal {
+  color: var(--frontend-docs-snippet-token-literal);
+}
+
+.frontend-docs-snippet-token-string {
+  color: var(--frontend-docs-snippet-token-string);
+}
+
+.frontend-docs-snippet-token-tag {
+  color: var(--frontend-docs-snippet-token-tag);
+}
+
+.frontend-docs-story-snippet,
+#storybook-docs .frontend-docs-story-snippet {
+  display: none;
+}
+
+:root[data-playground-code="show"] #storybook-root .frontend-docs-story-snippet {
+  display: grid;
+}
+
+@media (min-width: 64rem) {
+  :root[data-playground-code="show"]
+    #storybook-root
+    .frontend-docs-story-playground-content--has-snippet {
+    grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.95fr);
+  }
 }
 
 .docs-story,

--- a/apps/frontend-docs/shared/storybook/index.ts
+++ b/apps/frontend-docs/shared/storybook/index.ts
@@ -13,7 +13,15 @@ export {
   applyFrontendDocsManagerConfig,
   frontendDocsHiddenToolbarItems,
   frontendDocsManagerConfig,
+  registerFrontendDocsPlaygroundCodeTool,
 } from './managerConfig.ts';
+export {
+  frontendDocsPlaygroundCodeAttribute,
+  frontendDocsPlaygroundCodeChannelEvent,
+  frontendDocsPlaygroundCodeDefaultVisibility,
+  frontendDocsPlaygroundCodeStorageKey,
+  setupFrontendDocsPlaygroundCodePreview,
+} from './playgroundCodeRuntime.ts';
 export {
   createFrontendDocsPlaygroundParameters,
   type FrontendDocsPlaygroundAddonId,
@@ -21,6 +29,34 @@ export {
   type FrontendDocsPlaygroundParametersOptions,
   frontendDocsDefaultPlaygroundAddons,
 } from './playgroundParameters.ts';
-export { frontendDocsPreviewParameters } from './previewParameters.ts';
-export { StoryInfoPanel, StoryStack } from './reactStoryLayouts.tsx';
-export { withStoryStack } from './vueStoryTemplates.ts';
+export {
+  copyFrontendDocsSnippetToClipboard,
+  createFrontendDocsComponentSnippet,
+  createFrontendDocsHighlightedSnippetHtml,
+  type FrontendDocsComponentSnippetOptions,
+  type FrontendDocsSnippetProp,
+} from './playgroundSnippets.ts';
+export {
+  type FrontendDocsPlaygroundCodeVisibility,
+  type FrontendDocsPreviewGlobals,
+  frontendDocsPlaygroundCodeGlobalKey,
+  frontendDocsPreviewInitialGlobals,
+  frontendDocsPreviewParameters,
+  shouldShowFrontendDocsPlaygroundCode,
+} from './previewParameters.ts';
+export {
+  StoryInfoPanel,
+  StoryPlayground,
+  StoryPlaygroundContent,
+  StoryPlaygroundPreview,
+  StoryPlaygroundSnippet,
+  StoryStack,
+} from './reactStoryLayouts.tsx';
+export { frontendDocsStoryLayoutClasses } from './storyLayoutClasses.ts';
+export {
+  createVueStoryPreview,
+  createVueStorySourcePanel,
+  withStoryPlayground,
+  withStoryStack,
+  withVueStoryPlaygroundContent,
+} from './vueStoryTemplates.ts';

--- a/apps/frontend-docs/shared/storybook/managerConfig.ts
+++ b/apps/frontend-docs/shared/storybook/managerConfig.ts
@@ -1,3 +1,15 @@
+import type { ComponentType, ReactNode } from 'react';
+
+import {
+  applyFrontendDocsPlaygroundCodeVisibilityToDocument,
+  applyFrontendDocsPlaygroundCodeVisibilityToPreviewIframes,
+  emitFrontendDocsPlaygroundCodeVisibility,
+  type FrontendDocsPlaygroundCodeVisibility,
+  frontendDocsPlaygroundCodeStorageKey,
+  readFrontendDocsPlaygroundCodeVisibility,
+  writeFrontendDocsPlaygroundCodeVisibility,
+} from './playgroundCodeRuntime.ts';
+
 export const frontendDocsHiddenToolbarItems = {
   remount: {
     hidden: true,
@@ -15,12 +27,210 @@ export const frontendDocsHiddenToolbarItems = {
 
 export const frontendDocsManagerConfig = {
   toolbar: frontendDocsHiddenToolbarItems,
+  panelPosition: 'right',
 } as const;
 
 type StorybookManagerApi = {
   setConfig(config: typeof frontendDocsManagerConfig): void;
 };
 
+type StorybookToolbarApi = StorybookManagerApi & {
+  add(id: string, options: never): void;
+  getChannel(): {
+    emit(eventName: string, event: unknown): void;
+  };
+  register(id: string, callback: () => void): void;
+};
+
+type FrontendDocsPlaygroundCodeToolOptions = {
+  Button: ComponentType<FrontendDocsPlaygroundCodeButtonProps>;
+  React: Pick<typeof import('react'), 'createElement' | 'useEffect' | 'useState'>;
+  addons: StorybookToolbarApi;
+  types: {
+    TOOL: unknown;
+  };
+};
+
+type FrontendDocsPlaygroundCodeButtonProps = {
+  'aria-pressed'?: boolean;
+  ariaLabel: string;
+  children?: ReactNode;
+  id: string;
+  onClick: () => void;
+  tooltip: string;
+  variant: 'ghost';
+};
+
+const frontendDocsPlaygroundCodeAddonId = '@hoite-dev/frontend-docs/playground-code';
+const frontendDocsPlaygroundCodeButtonId = 'frontend-docs-playground-code-tool';
+const frontendDocsPlaygroundCodeToolId = `${frontendDocsPlaygroundCodeAddonId}/tool`;
+const frontendDocsPlaygroundCodeWindowFlag = '__frontendDocsPlaygroundCodeToolRegistered__';
+const frontendDocsPlaygroundCodeTitle = 'Snippets: Show code snippets in playgrounds for easy copy';
+const storybookPreviewWrapperId = 'storybook-preview-wrapper';
+
+function createCodeIcon(React: Pick<typeof import('react'), 'createElement'>): ReactNode {
+  return React.createElement(
+    'svg',
+    {
+      'aria-hidden': true,
+      focusable: false,
+      height: 14,
+      style: {
+        display: 'inline-block',
+        marginRight: 6,
+        verticalAlign: 'text-bottom',
+      },
+      viewBox: '0 0 16 16',
+      width: 14,
+    },
+    React.createElement('path', {
+      d: 'M6.2 4.2 2.4 8l3.8 3.8-.9.9L.6 8l4.7-4.7.9.9Zm3.6 7.6L13.6 8 9.8 4.2l.9-.9L15.4 8l-4.7 4.7-.9-.9Z',
+      fill: 'currentColor',
+    }),
+  );
+}
+
+function resolveNextPlaygroundCodeVisibility(
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+): FrontendDocsPlaygroundCodeVisibility {
+  if (visibility === 'show') {
+    return 'hide';
+  }
+
+  return 'show';
+}
+
+function applyPlaygroundCodeVisibility(visibility: FrontendDocsPlaygroundCodeVisibility): void {
+  applyFrontendDocsPlaygroundCodeVisibilityToDocument(visibility);
+  applyFrontendDocsPlaygroundCodeVisibilityToPreviewIframes(visibility);
+}
+
 export function applyFrontendDocsManagerConfig(addons: StorybookManagerApi): void {
   addons.setConfig(frontendDocsManagerConfig);
+}
+
+export function registerFrontendDocsPlaygroundCodeTool({
+  addons,
+  Button,
+  React,
+  types,
+}: FrontendDocsPlaygroundCodeToolOptions): void {
+  const windowRecord = window as Window & {
+    [frontendDocsPlaygroundCodeWindowFlag]?: boolean;
+  };
+
+  if (windowRecord[frontendDocsPlaygroundCodeWindowFlag]) {
+    return;
+  }
+
+  function PlaygroundCodeTool() {
+    const [visibility, setVisibility] = React.useState<FrontendDocsPlaygroundCodeVisibility>(() =>
+      readFrontendDocsPlaygroundCodeVisibility(),
+    );
+    const showCode = visibility === 'show';
+    const label = showCode ? 'Snippets: Shown' : 'Snippets: Hidden';
+
+    React.useEffect(() => {
+      applyPlaygroundCodeVisibility(visibility);
+    }, [visibility]);
+
+    React.useEffect(() => {
+      let scheduledFrameId: number | null = null;
+
+      const applyCurrentVisibility = () => {
+        applyPlaygroundCodeVisibility(readFrontendDocsPlaygroundCodeVisibility());
+      };
+
+      const scheduleVisibilityApplication = () => {
+        if (scheduledFrameId !== null) {
+          return;
+        }
+
+        scheduledFrameId = window.requestAnimationFrame(() => {
+          scheduledFrameId = null;
+          applyCurrentVisibility();
+        });
+      };
+
+      const handleStorage = (event: StorageEvent) => {
+        if (event.key !== frontendDocsPlaygroundCodeStorageKey) {
+          return;
+        }
+
+        const nextVisibility = readFrontendDocsPlaygroundCodeVisibility();
+        setVisibility(nextVisibility);
+        applyPlaygroundCodeVisibility(nextVisibility);
+      };
+
+      const previewWrapper = document.getElementById(storybookPreviewWrapperId);
+      const observer = new MutationObserver(() => {
+        scheduleVisibilityApplication();
+      });
+
+      if (previewWrapper) {
+        observer.observe(previewWrapper, {
+          attributeFilter: ['data-is-loaded', 'data-is-storybook', 'src'],
+          attributes: true,
+          childList: true,
+          subtree: true,
+        });
+      }
+
+      window.addEventListener('focus', scheduleVisibilityApplication);
+      window.addEventListener('pageshow', scheduleVisibilityApplication);
+      window.addEventListener('storage', handleStorage);
+      window.addEventListener('load', scheduleVisibilityApplication, true);
+      scheduleVisibilityApplication();
+
+      return () => {
+        if (scheduledFrameId !== null) {
+          window.cancelAnimationFrame(scheduledFrameId);
+        }
+
+        observer.disconnect();
+        window.removeEventListener('focus', scheduleVisibilityApplication);
+        window.removeEventListener('pageshow', scheduleVisibilityApplication);
+        window.removeEventListener('storage', handleStorage);
+        window.removeEventListener('load', scheduleVisibilityApplication, true);
+      };
+    }, []);
+
+    return React.createElement(
+      Button,
+      {
+        'aria-pressed': showCode,
+        ariaLabel: frontendDocsPlaygroundCodeTitle,
+        id: frontendDocsPlaygroundCodeButtonId,
+        onClick: () => {
+          const nextVisibility = resolveNextPlaygroundCodeVisibility(visibility);
+
+          writeFrontendDocsPlaygroundCodeVisibility(nextVisibility);
+          applyPlaygroundCodeVisibility(nextVisibility);
+          emitFrontendDocsPlaygroundCodeVisibility(addons.getChannel(), nextVisibility);
+          setVisibility(nextVisibility);
+        },
+        tooltip: frontendDocsPlaygroundCodeTitle,
+        variant: 'ghost',
+      } satisfies FrontendDocsPlaygroundCodeButtonProps,
+      createCodeIcon(React),
+      label,
+    );
+  }
+
+  addons.register(frontendDocsPlaygroundCodeAddonId, () => {
+    addons.add(frontendDocsPlaygroundCodeToolId, {
+      match: ({ tabId, viewMode }: { tabId?: string; viewMode?: string }) => {
+        if (tabId) {
+          return false;
+        }
+
+        return viewMode === 'story' || viewMode === 'docs';
+      },
+      render: PlaygroundCodeTool,
+      title: 'Playground snippets',
+      type: types.TOOL,
+    } as never);
+  });
+
+  windowRecord[frontendDocsPlaygroundCodeWindowFlag] = true;
 }

--- a/apps/frontend-docs/shared/storybook/playgroundCodeRuntime.ts
+++ b/apps/frontend-docs/shared/storybook/playgroundCodeRuntime.ts
@@ -1,0 +1,164 @@
+export type FrontendDocsPlaygroundCodeVisibility = 'hide' | 'show';
+
+export const frontendDocsPlaygroundCodeAttribute = 'data-playground-code';
+export const frontendDocsPlaygroundCodeChannelEvent = 'frontend-docs/playground-code-selected';
+export const frontendDocsPlaygroundCodeDefaultVisibility = 'hide';
+export const frontendDocsPlaygroundCodeStorageKey = 'hoite-dev:frontend-docs:playground-code';
+export const frontendDocsPlaygroundCodeWindowMessageType =
+  'hoite-dev:frontend-docs:playground-code';
+
+const storybookPreviewWrapperId = 'storybook-preview-wrapper';
+const storybookPreviewIframeId = 'storybook-preview-iframe';
+const storybookRefIframeIdPrefix = 'storybook-ref-';
+
+type StorybookChannel = {
+  emit?(eventName: string, event: unknown): void;
+  on?(eventName: string, handler: (event: unknown) => void): void;
+};
+
+function isPlaygroundCodeVisibility(value: unknown): value is FrontendDocsPlaygroundCodeVisibility {
+  return value === 'hide' || value === 'show';
+}
+
+export function readFrontendDocsPlaygroundCodeVisibility(): FrontendDocsPlaygroundCodeVisibility {
+  try {
+    const storedValue = window.localStorage.getItem(frontendDocsPlaygroundCodeStorageKey);
+
+    if (isPlaygroundCodeVisibility(storedValue)) {
+      return storedValue;
+    }
+  } catch {
+    return frontendDocsPlaygroundCodeDefaultVisibility;
+  }
+
+  return frontendDocsPlaygroundCodeDefaultVisibility;
+}
+
+export function writeFrontendDocsPlaygroundCodeVisibility(
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+): void {
+  try {
+    window.localStorage.setItem(frontendDocsPlaygroundCodeStorageKey, visibility);
+  } catch {
+    return;
+  }
+}
+
+export function applyFrontendDocsPlaygroundCodeVisibilityToDocument(
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+  targetDocument: Document = document,
+): void {
+  targetDocument.documentElement.setAttribute(frontendDocsPlaygroundCodeAttribute, visibility);
+}
+
+function getStorybookPreviewIframes(targetDocument: Document = document): HTMLIFrameElement[] {
+  const previewWrapper = targetDocument.getElementById(storybookPreviewWrapperId);
+  const searchRoot = previewWrapper ?? targetDocument;
+
+  return Array.from(
+    searchRoot.querySelectorAll<HTMLIFrameElement>(
+      `#${storybookPreviewIframeId}, iframe[id^="${storybookRefIframeIdPrefix}"]`,
+    ),
+  );
+}
+
+function applyVisibilityToIframeDocument(
+  iframe: HTMLIFrameElement,
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+): void {
+  try {
+    const previewDocument = iframe.contentDocument;
+
+    if (previewDocument !== null) {
+      applyFrontendDocsPlaygroundCodeVisibilityToDocument(visibility, previewDocument);
+    }
+  } catch {
+    return;
+  }
+}
+
+function postVisibilityToIframe(
+  iframe: HTMLIFrameElement,
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+): void {
+  iframe.contentWindow?.postMessage(
+    {
+      type: frontendDocsPlaygroundCodeWindowMessageType,
+      visibility,
+    },
+    '*',
+  );
+}
+
+export function applyFrontendDocsPlaygroundCodeVisibilityToPreviewIframes(
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+): void {
+  for (const iframe of getStorybookPreviewIframes()) {
+    applyVisibilityToIframeDocument(iframe, visibility);
+    postVisibilityToIframe(iframe, visibility);
+  }
+}
+
+export function emitFrontendDocsPlaygroundCodeVisibility(
+  channel: StorybookChannel,
+  visibility: FrontendDocsPlaygroundCodeVisibility,
+): void {
+  channel.emit?.(frontendDocsPlaygroundCodeChannelEvent, {
+    visibility,
+  });
+}
+
+function readVisibilityFromEvent(event: unknown): FrontendDocsPlaygroundCodeVisibility | null {
+  if (typeof event !== 'object' || event === null || Array.isArray(event)) {
+    return null;
+  }
+
+  const visibility = (event as { visibility?: unknown }).visibility;
+
+  if (isPlaygroundCodeVisibility(visibility)) {
+    return visibility;
+  }
+
+  return null;
+}
+
+export function setupFrontendDocsPlaygroundCodePreview(channel: StorybookChannel): void {
+  applyFrontendDocsPlaygroundCodeVisibilityToDocument(readFrontendDocsPlaygroundCodeVisibility());
+
+  window.addEventListener('storage', (event) => {
+    if (event.key !== frontendDocsPlaygroundCodeStorageKey) {
+      return;
+    }
+
+    applyFrontendDocsPlaygroundCodeVisibilityToDocument(readFrontendDocsPlaygroundCodeVisibility());
+  });
+
+  window.addEventListener('message', (event) => {
+    if (
+      typeof event.data !== 'object' ||
+      event.data === null ||
+      Array.isArray(event.data) ||
+      event.data.type !== frontendDocsPlaygroundCodeWindowMessageType
+    ) {
+      return;
+    }
+
+    const visibility = readVisibilityFromEvent(event.data);
+
+    if (visibility === null) {
+      return;
+    }
+
+    applyFrontendDocsPlaygroundCodeVisibilityToDocument(visibility);
+  });
+
+  channel.on?.(frontendDocsPlaygroundCodeChannelEvent, (event) => {
+    const visibility = readVisibilityFromEvent(event);
+
+    if (visibility === null) {
+      return;
+    }
+
+    applyFrontendDocsPlaygroundCodeVisibilityToDocument(visibility);
+  });
+}

--- a/apps/frontend-docs/shared/storybook/playgroundCodeRuntime.ts
+++ b/apps/frontend-docs/shared/storybook/playgroundCodeRuntime.ts
@@ -2,7 +2,7 @@ export type FrontendDocsPlaygroundCodeVisibility = 'hide' | 'show';
 
 export const frontendDocsPlaygroundCodeAttribute = 'data-playground-code';
 export const frontendDocsPlaygroundCodeChannelEvent = 'frontend-docs/playground-code-selected';
-export const frontendDocsPlaygroundCodeDefaultVisibility = 'hide';
+export const frontendDocsPlaygroundCodeDefaultVisibility = 'show';
 export const frontendDocsPlaygroundCodeStorageKey = 'hoite-dev:frontend-docs:playground-code';
 export const frontendDocsPlaygroundCodeWindowMessageType =
   'hoite-dev:frontend-docs:playground-code';

--- a/apps/frontend-docs/shared/storybook/playgroundSnippets.ts
+++ b/apps/frontend-docs/shared/storybook/playgroundSnippets.ts
@@ -1,0 +1,173 @@
+type FrontendDocsSnippetFramework = 'react' | 'vue';
+
+type FrontendDocsSnippetPropValue = boolean | number | string | null | undefined;
+
+export type FrontendDocsSnippetProp = {
+  defaultValue?: FrontendDocsSnippetPropValue;
+  name: string;
+  value: FrontendDocsSnippetPropValue;
+};
+
+export type FrontendDocsComponentSnippetOptions = {
+  children?: string;
+  componentName: string;
+  framework: FrontendDocsSnippetFramework;
+  props?: readonly FrontendDocsSnippetProp[];
+};
+
+function escapeAttributeValue(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function escapeTextContent(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('{', '&#123;')
+    .replaceAll('}', '&#125;');
+}
+
+function escapeSnippetHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function createSnippetToken(className: string, value: string): string {
+  return `<span class="${className}">${escapeSnippetHtml(value)}</span>`;
+}
+
+function shouldRenderProp(prop: FrontendDocsSnippetProp): boolean {
+  if (prop.value === undefined || prop.value === null || prop.value === '') {
+    return false;
+  }
+
+  return prop.value !== prop.defaultValue;
+}
+
+function formatReactProp({ name, value }: FrontendDocsSnippetProp): string {
+  if (typeof value === 'boolean') {
+    return value ? name : `${name}={false}`;
+  }
+
+  if (typeof value === 'number') {
+    return `${name}={${value}}`;
+  }
+
+  return `${name}="${escapeAttributeValue(String(value))}"`;
+}
+
+function formatVueProp({ name, value }: FrontendDocsSnippetProp): string {
+  if (typeof value === 'boolean') {
+    return value ? name : `:${name}="false"`;
+  }
+
+  if (typeof value === 'number') {
+    return `:${name}="${value}"`;
+  }
+
+  return `${name}="${escapeAttributeValue(String(value))}"`;
+}
+
+function formatProp(
+  framework: FrontendDocsSnippetFramework,
+  prop: FrontendDocsSnippetProp,
+): string {
+  if (framework === 'vue') {
+    return formatVueProp(prop);
+  }
+
+  return formatReactProp(prop);
+}
+
+function formatOpeningTag({
+  componentName,
+  framework,
+  props = [],
+}: FrontendDocsComponentSnippetOptions): string {
+  const renderedProps = props.filter(shouldRenderProp).map((prop) => formatProp(framework, prop));
+
+  if (renderedProps.length === 0) {
+    return `<${componentName}`;
+  }
+
+  if (renderedProps.length === 1) {
+    return `<${componentName} ${renderedProps[0]}`;
+  }
+
+  return [`<${componentName}`, ...renderedProps.map((prop) => `  ${prop}`)].join('\n');
+}
+
+function formatChildren(children: string): string {
+  return escapeTextContent(children)
+    .split('\n')
+    .map((line) => `  ${line}`)
+    .join('\n');
+}
+
+export function createFrontendDocsComponentSnippet(
+  options: FrontendDocsComponentSnippetOptions,
+): string {
+  const openingTag = formatOpeningTag(options);
+  const hasMultilineOpeningTag = openingTag.includes('\n');
+
+  if (options.children === undefined || options.children.length === 0) {
+    return `${openingTag}${hasMultilineOpeningTag ? '\n' : ' '}/>`;
+  }
+
+  return [`${openingTag}>`, formatChildren(options.children), `</${options.componentName}>`].join(
+    '\n',
+  );
+}
+
+export async function copyFrontendDocsSnippetToClipboard(snippet: string): Promise<boolean> {
+  if (!globalThis.navigator?.clipboard) {
+    return false;
+  }
+
+  await globalThis.navigator.clipboard.writeText(snippet);
+  return true;
+}
+
+export function createFrontendDocsHighlightedSnippetHtml(snippet: string): string {
+  const tokenPattern =
+    /("[^"\n]*")|(<\/?)([A-Z][A-Za-z0-9.]*)|(\s)(:?[A-Za-z][A-Za-z0-9-]*)(=)|(\{(?:false|true|\d+)\}|(?:false|true|\d+))/g;
+  let highlightedSnippet = '';
+  let lastIndex = 0;
+
+  for (const match of snippet.matchAll(tokenPattern)) {
+    const matchIndex = match.index ?? 0;
+
+    highlightedSnippet += escapeSnippetHtml(snippet.slice(lastIndex, matchIndex));
+
+    if (match[1]) {
+      highlightedSnippet += createSnippetToken('frontend-docs-snippet-token-string', match[1]);
+    } else if (match[2] && match[3]) {
+      highlightedSnippet += `${escapeSnippetHtml(match[2])}${createSnippetToken(
+        'frontend-docs-snippet-token-tag',
+        match[3],
+      )}`;
+    } else if (match[4] && match[5] && match[6]) {
+      highlightedSnippet += `${escapeSnippetHtml(match[4])}${createSnippetToken(
+        'frontend-docs-snippet-token-attribute',
+        match[5],
+      )}${escapeSnippetHtml(match[6])}`;
+    } else if (match[7]) {
+      highlightedSnippet += createSnippetToken('frontend-docs-snippet-token-literal', match[7]);
+    } else {
+      highlightedSnippet += escapeSnippetHtml(match[0]);
+    }
+
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  highlightedSnippet += escapeSnippetHtml(snippet.slice(lastIndex));
+  return highlightedSnippet;
+}

--- a/apps/frontend-docs/shared/storybook/prepareStorybook.mjs
+++ b/apps/frontend-docs/shared/storybook/prepareStorybook.mjs
@@ -36,12 +36,17 @@ function runPnpm(commandArgs) {
 }
 
 if (shouldClearCache) {
-  const storybookCachePath = path.resolve(process.cwd(), 'node_modules/.cache/storybook');
+  const storybookCachePaths = [
+    path.resolve(process.cwd(), 'node_modules/.cache/storybook'),
+    path.resolve(process.cwd(), 'storybook-static'),
+  ];
 
-  rmSync(storybookCachePath, {
-    force: true,
-    recursive: true,
-  });
+  for (const storybookCachePath of storybookCachePaths) {
+    rmSync(storybookCachePath, {
+      force: true,
+      recursive: true,
+    });
+  }
 }
 
 if (shouldSyncBrandAssets) {

--- a/apps/frontend-docs/shared/storybook/previewParameters.ts
+++ b/apps/frontend-docs/shared/storybook/previewParameters.ts
@@ -1,5 +1,29 @@
+import type { FrontendDocsPlaygroundCodeVisibility } from './playgroundCodeRuntime.ts';
+import { frontendDocsPlaygroundCodeDefaultVisibility } from './playgroundCodeRuntime.ts';
+
+export type { FrontendDocsPlaygroundCodeVisibility } from './playgroundCodeRuntime.ts';
+
 export const frontendDocsPreviewParameters = {
   backgrounds: {
     disable: true,
   },
 } as const;
+
+export const frontendDocsPlaygroundCodeGlobalKey = 'playgroundCode';
+
+export const frontendDocsPreviewInitialGlobals = {
+  [frontendDocsPlaygroundCodeGlobalKey]: frontendDocsPlaygroundCodeDefaultVisibility,
+} satisfies Record<
+  typeof frontendDocsPlaygroundCodeGlobalKey,
+  FrontendDocsPlaygroundCodeVisibility
+>;
+
+export type FrontendDocsPreviewGlobals = {
+  playgroundCode?: FrontendDocsPlaygroundCodeVisibility;
+};
+
+export function shouldShowFrontendDocsPlaygroundCode(
+  globals: FrontendDocsPreviewGlobals | undefined,
+): boolean {
+  return globals?.playgroundCode === 'show';
+}

--- a/apps/frontend-docs/shared/storybook/reactStoryLayouts.tsx
+++ b/apps/frontend-docs/shared/storybook/reactStoryLayouts.tsx
@@ -1,8 +1,6 @@
 import { createElement, type ReactNode } from 'react';
 
-const stackBaseClassName = 'grid gap-4';
-const infoPanelBaseClassName =
-  'rounded-xl border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4';
+import { frontendDocsStoryLayoutClasses } from './storyLayoutClasses.ts';
 
 type StoryStackProps = {
   children: ReactNode;
@@ -14,6 +12,14 @@ type StoryInfoPanelProps = {
   className?: string;
 };
 
+type StoryPlaygroundSnippetProps = {
+  children: ReactNode;
+};
+
+type StoryPlaygroundContentProps = StoryStackProps & {
+  split?: boolean;
+};
+
 function joinClassNames(...classNames: Array<string | undefined>): string {
   return classNames
     .filter((className) => className !== undefined && className.length > 0)
@@ -23,7 +29,7 @@ function joinClassNames(...classNames: Array<string | undefined>): string {
 export function StoryStack({ children, className }: StoryStackProps) {
   return createElement(
     'div',
-    { className: joinClassNames(stackBaseClassName, className) },
+    { className: joinClassNames(frontendDocsStoryLayoutClasses.stack, className) },
     children,
   );
 }
@@ -31,7 +37,45 @@ export function StoryStack({ children, className }: StoryStackProps) {
 export function StoryInfoPanel({ children, className }: StoryInfoPanelProps) {
   return createElement(
     'div',
-    { className: joinClassNames(infoPanelBaseClassName, className) },
+    { className: joinClassNames(frontendDocsStoryLayoutClasses.infoPanel, className) },
     children,
   );
+}
+
+export function StoryPlayground({ children, className }: StoryStackProps) {
+  return createElement(
+    'div',
+    { className: joinClassNames(frontendDocsStoryLayoutClasses.playground, className) },
+    children,
+  );
+}
+
+export function StoryPlaygroundContent({
+  children,
+  className,
+  split = false,
+}: StoryPlaygroundContentProps) {
+  return createElement(
+    'div',
+    {
+      className: joinClassNames(
+        frontendDocsStoryLayoutClasses.playgroundContent,
+        split ? frontendDocsStoryLayoutClasses.playgroundContentSplit : undefined,
+        className,
+      ),
+    },
+    children,
+  );
+}
+
+export function StoryPlaygroundPreview({ children, className }: StoryStackProps) {
+  return createElement(
+    'div',
+    { className: joinClassNames(frontendDocsStoryLayoutClasses.playgroundPreview, className) },
+    children,
+  );
+}
+
+export function StoryPlaygroundSnippet({ children }: StoryPlaygroundSnippetProps) {
+  return createElement('div', { className: frontendDocsStoryLayoutClasses.snippetPanel }, children);
 }

--- a/apps/frontend-docs/shared/storybook/storyLayoutClasses.ts
+++ b/apps/frontend-docs/shared/storybook/storyLayoutClasses.ts
@@ -1,0 +1,15 @@
+export const frontendDocsStoryLayoutClasses = {
+  infoPanel: 'rounded-lg border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-4',
+  playground: 'mx-auto grid w-full max-w-5xl gap-6',
+  playgroundContent: 'frontend-docs-story-playground-content grid gap-6',
+  playgroundContentSplit: 'frontend-docs-story-playground-content--has-snippet',
+  playgroundPreview: 'grid place-items-center py-10',
+  snippetBody:
+    'relative overflow-hidden rounded-lg border border-[var(--color-border-muted)] bg-surface-raised',
+  snippetCode: 'block whitespace-pre text-sm leading-6 text-[var(--color-text-primary)]',
+  snippetCopyButton:
+    'absolute bottom-0 right-0 inline-flex w-fit items-center gap-1.5 border border-[var(--color-border-muted)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-primary)]',
+  snippetPanel: 'frontend-docs-story-snippet mx-auto grid w-full max-w-[56ch] gap-2',
+  snippetPre: 'm-0 overflow-x-auto p-4',
+  stack: 'grid gap-4',
+} as const;

--- a/apps/frontend-docs/shared/storybook/storyLayoutClasses.ts
+++ b/apps/frontend-docs/shared/storybook/storyLayoutClasses.ts
@@ -4,8 +4,7 @@ export const frontendDocsStoryLayoutClasses = {
   playgroundContent: 'frontend-docs-story-playground-content grid gap-6',
   playgroundContentSplit: 'frontend-docs-story-playground-content--has-snippet',
   playgroundPreview: 'grid place-items-center py-10',
-  snippetBody:
-    'relative overflow-hidden rounded-lg border border-[var(--color-border-muted)] bg-surface-raised',
+  snippetBody: 'relative overflow-hidden rounded-lg border border-[var(--color-border-muted)]',
   snippetCode: 'block whitespace-pre text-sm leading-6 text-[var(--color-text-primary)]',
   snippetCopyButton:
     'absolute bottom-0 right-0 inline-flex w-fit items-center gap-1.5 border border-[var(--color-border-muted)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-primary)]',

--- a/apps/frontend-docs/shared/storybook/vueStoryTemplates.ts
+++ b/apps/frontend-docs/shared/storybook/vueStoryTemplates.ts
@@ -1,9 +1,54 @@
-const storyStackClassName = 'grid gap-4';
+import { frontendDocsStoryLayoutClasses } from './storyLayoutClasses.ts';
 
 export function withStoryStack(content: string): string {
   return `
-    <div class="${storyStackClassName}">
+    <div class="${frontendDocsStoryLayoutClasses.stack}">
 ${content}
     </div>
+  `;
+}
+
+export function withStoryPlayground(content: string): string {
+  return `
+    <div class="${frontendDocsStoryLayoutClasses.playground}">
+${content}
+    </div>
+  `;
+}
+
+export function createVueStoryPreview(content: string, className = ''): string {
+  return `
+      <div class="${frontendDocsStoryLayoutClasses.playgroundPreview} ${className}">
+${content}
+      </div>
+  `;
+}
+
+export function withVueStoryPlaygroundContent(content: string): string {
+  return `
+      <div
+        class="${frontendDocsStoryLayoutClasses.playgroundContent} ${frontendDocsStoryLayoutClasses.playgroundContentSplit}"
+      >
+${content}
+      </div>
+  `;
+}
+
+export function createVueStorySourcePanel(
+  highlightedSnippetExpression = 'highlightedSnippet',
+): string {
+  return `
+      <div class="${frontendDocsStoryLayoutClasses.snippetPanel}">
+        <div class="${frontendDocsStoryLayoutClasses.snippetBody}">
+          <pre class="${frontendDocsStoryLayoutClasses.snippetPre}"><code class="${frontendDocsStoryLayoutClasses.snippetCode}" v-html="${highlightedSnippetExpression}"></code></pre>
+          <button class="${frontendDocsStoryLayoutClasses.snippetCopyButton}" type="button" @click="copySnippet">
+            <svg aria-hidden="true" class="size-3.5" viewBox="0 0 16 16">
+              <path fill="currentColor" d="M5 1.5h6A1.5 1.5 0 0 1 12.5 3v8A1.5 1.5 0 0 1 11 12.5H5A1.5 1.5 0 0 1 3.5 11V3A1.5 1.5 0 0 1 5 1.5Zm0 1A.5.5 0 0 0 4.5 3v8a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 .5-.5V3a.5.5 0 0 0-.5-.5H5Z" />
+              <path fill="currentColor" d="M2 4.5h1v7A1.5 1.5 0 0 0 4.5 13H10v1H4.5A2.5 2.5 0 0 1 2 11.5v-7Z" />
+            </svg>
+            {{ copyButtonLabel }}
+          </button>
+        </div>
+      </div>
   `;
 }

--- a/apps/frontend-docs/site-nuxt-components/package.json
+++ b/apps/frontend-docs/site-nuxt-components/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear",
-    "predev": "node ../shared/storybook/prepareStorybook.mjs",
+    "prebuild": "node ../shared/storybook/prepareStorybook.mjs",
+    "predev": "node ../shared/storybook/prepareStorybook.mjs --skip-cache-clear",
     "build": "storybook build",
     "dev": "storybook dev --host site-nuxt-components.local.hoite.dev --port 6009 --https --ssl-cert ../../../ssl/local.hoite.dev.pem --ssl-key ../../../ssl/local.hoite.dev-key.pem",
     "format": "biome check --write .storybook src package.json tsconfig.json README.md",

--- a/packages/storybook-addon-composition-theme/src/config.ts
+++ b/packages/storybook-addon-composition-theme/src/config.ts
@@ -17,6 +17,7 @@ export type CompositionThemeLightDarkConfig<ThemeId extends string = string> =
     toolbar?: {
       control?: 'toggle' | 'buttons';
       label?: string;
+      title?: string;
     };
   };
 
@@ -27,6 +28,7 @@ export type CompositionThemeCustomConfig<ThemeId extends string = string> =
     toolbar?: {
       control?: 'dropdown' | 'buttons';
       label?: string;
+      title?: string;
     };
   } & (
       | {
@@ -54,6 +56,7 @@ export type ResolvedCompositionThemeLightDarkConfig<ThemeId extends string = str
   toolbar: {
     control: 'toggle' | 'buttons';
     label: string;
+    title?: string;
   };
 };
 
@@ -65,6 +68,7 @@ export type ResolvedCompositionThemeCustomConfig<ThemeId extends string = string
   toolbar: {
     control: 'dropdown' | 'buttons';
     label: string;
+    title?: string;
   };
 };
 
@@ -132,6 +136,16 @@ function resolveToolbarLabel(label: string | undefined): string {
   assertNonEmptyString(label, 'toolbar.label');
 
   return label;
+}
+
+function resolveToolbarTitle(title: string | undefined): string | undefined {
+  if (title === undefined) {
+    return undefined;
+  }
+
+  assertNonEmptyString(title, 'toolbar.title');
+
+  return title;
 }
 
 function ensureLightDarkConfigIsValid(config: CompositionThemeLightDarkConfig) {
@@ -244,6 +258,7 @@ export function defineCompositionThemeConfig<ThemeId extends string>(
       toolbar: {
         control: config.toolbar?.control ?? 'toggle',
         label: resolveToolbarLabel(config.toolbar?.label),
+        title: resolveToolbarTitle(config.toolbar?.title),
       },
     };
 
@@ -260,6 +275,7 @@ export function defineCompositionThemeConfig<ThemeId extends string>(
     toolbar: {
       control: config.toolbar?.control ?? 'dropdown',
       label: resolveToolbarLabel(config.toolbar?.label),
+      title: resolveToolbarTitle(config.toolbar?.title),
     },
   };
 

--- a/packages/storybook-addon-composition-theme/src/manager.tsx
+++ b/packages/storybook-addon-composition-theme/src/manager.tsx
@@ -20,6 +20,7 @@ import {
 } from './runtime.js';
 
 const COMPOSITION_THEME_ADDON_ID = '@hoite-dev/storybook-addon-composition-theme';
+const COMPOSITION_THEME_BUTTON_ID = 'composition-theme-tool';
 const COMPOSITION_THEME_TOOL_ID = `${COMPOSITION_THEME_ADDON_ID}/tool`;
 const MANAGER_REGISTRATION_WINDOW_FLAG = '__compositionThemeManagerRegistered__';
 
@@ -227,15 +228,17 @@ function CompositionThemeTool({ config }: CompositionThemeToolProps) {
     }
 
     const icon = currentThemeId === config.lightTheme.id ? <SunThemeIcon /> : <MoonThemeIcon />;
+    const title = config.toolbar.title ?? `${config.toolbar.label}: ${currentLabel}`;
 
     return (
       <Button
-        ariaLabel={`${config.toolbar.label}: ${currentLabel}`}
+        ariaLabel={title}
+        id={COMPOSITION_THEME_BUTTON_ID}
         key={COMPOSITION_THEME_TOOL_ID}
         onClick={() => {
           setExplicitTheme(nextThemeId);
         }}
-        tooltip={`${config.toolbar.label}: ${currentLabel}`}
+        tooltip={title}
         variant='ghost'
       >
         {icon}
@@ -247,10 +250,11 @@ function CompositionThemeTool({ config }: CompositionThemeToolProps) {
   if (config.kind === 'custom' && config.toolbar.control === 'dropdown') {
     const resolvedThemeId = selectedThemeOption?.id ?? themeOptions[0]?.id;
     const currentLabel = selectedThemeOption?.label ?? config.toolbar.label;
+    const title = config.toolbar.title ?? `${config.toolbar.label}: ${currentLabel}`;
 
     return (
       <Select
-        ariaLabel={`${config.toolbar.label}: ${currentLabel}`}
+        ariaLabel={title}
         defaultOptions={resolvedThemeId}
         key={COMPOSITION_THEME_TOOL_ID}
         onSelect={(value) => {
@@ -341,7 +345,7 @@ function registerManagerTool(config: ResolvedCompositionThemeConfig) {
         return viewMode === 'story' || viewMode === 'docs';
       },
       render: () => <CompositionThemeTool config={config} />,
-      title: config.toolbar.label,
+      title: config.toolbar.title ?? config.toolbar.label,
       type: types.TOOL,
     });
   });

--- a/packages/ui/src/components/primitives/static/icon/icon.docs.ts
+++ b/packages/ui/src/components/primitives/static/icon/icon.docs.ts
@@ -27,25 +27,31 @@ export const iconDocs = {
   sections: [
     {
       items: [
-        'Use `name`, `size`, `rotation`, and `variant` as the main visual API.',
-        'Keep interactive icon-only behavior in `IconButton`; `Icon` stays a static SVG primitive.',
+        'Use [code]name[/code], [code]size[/code], [code]rotation[/code], and [code]variant[/code] as the main visual API.',
+        'Keep interactive icon-only behavior in [code]IconButton[/code]; [code]Icon[/code] stays a static SVG primitive.',
       ],
       title: 'Usage Notes',
     },
     {
       items: [
-        'Meaningful icons should receive an accessible name with `label` or `aria-label`.',
-        'Icons without `label` or `aria-label` are decorative and hidden from assistive technology.',
-        'If both are provided, `label` wins.',
+        'Meaningful icons should receive an accessible name with [code]label[/code] or [code]aria-label[/code].',
+        'Icons without [code]label[/code] or [code]aria-label[/code] are decorative and hidden from assistive technology.',
+        'If both are provided, [code]label[/code] wins.',
       ],
       title: 'Accessibility Notes',
     },
     {
       items: [
-        'Storybook controls focus on the visual API: `name`, `size`, `rotation`, and `variant`.',
-        'Narrow passthrough attributes such as `id`, `title`, `role`, `aria-label`, and deliberate `data-*` attributes are supported but not exposed as noisy playground controls.',
+        'Storybook controls focus on the visual API: [code]name[/code], [code]size[/code], [code]rotation[/code], and [code]variant[/code].',
+        'Narrow passthrough attributes such as [code]id[/code], [code]title[/code], [code]role[/code], [code]aria-label[/code], and deliberate [code]data-*[/code] attributes are supported but not exposed as noisy playground controls.',
       ],
       title: 'Controls Guidance',
+    },
+    {
+      paragraphs: [
+        'Icon SVG path data is derived from [url=https://github.com/tabler/tabler-icons]Tabler Icons[/url], which is licensed under the MIT License.',
+      ],
+      title: 'Attribution',
     },
   ] satisfies readonly DocsSection[],
   sourceLinks: [

--- a/packages/ui/src/components/primitives/static/icon/icons/arrow.ts
+++ b/packages/ui/src/components/primitives/static/icon/icons/arrow.ts
@@ -1,3 +1,3 @@
 import { defineIcon } from './defineIcon';
 
-export const arrowIcon = defineIcon('arrow', ['M5 12H19', 'M13 18L19 12', 'M13 6L19 12']);
+export const arrowIcon = defineIcon('arrow', ['M12 5V19', 'M18 13L12 19', 'M6 13L12 19']);

--- a/packages/ui/src/components/primitives/static/loading/loading.docs.ts
+++ b/packages/ui/src/components/primitives/static/loading/loading.docs.ts
@@ -35,25 +35,25 @@ export const loadingDocs = {
   sections: [
     {
       items: [
-        'Use `Loader` for non-quantified wait states and `Progress` or `CircularProgress` when a numeric completion value is meaningful.',
-        'All three primitives share the same `size` and `color` model so loading states stay visually consistent.',
-        'Progress primitives normalize invalid `max` and `value` input and clamp out-of-range values before rendering.',
+        'Use [code]Loader[/code] for non-quantified wait states and [code]Progress[/code] or [code]CircularProgress[/code] when a numeric completion value is meaningful.',
+        'All three primitives share the same [code]size[/code] and [code]color[/code] model so loading states stay visually consistent.',
+        'Progress primitives normalize invalid [code]max[/code] and [code]value[/code] input and clamp out-of-range values before rendering.',
         'Indeterminate states include built-in motion; reduced-motion settings disable those animations.',
       ],
       title: 'Usage Notes',
     },
     {
       items: [
-        'Provide a visible `label` for `Progress` and `CircularProgress` when possible. Wrappers connect labels to native progress semantics.',
-        'For unlabeled usage, pass `aria-label` or `aria-labelledby` so assistive technologies announce purpose and state.',
-        'Progress and CircularProgress keep a native `<progress>` element as the semantic source while custom visuals remain `aria-hidden`.',
+        'Provide a visible [code]label[/code] for [code]Progress[/code] and [code]CircularProgress[/code] when possible. Wrappers connect labels to native progress semantics.',
+        'For unlabeled usage, pass [code]aria-label[/code] or [code]aria-labelledby[/code] so assistive technologies announce purpose and state.',
+        'Progress and CircularProgress keep a native [code]<progress>[/code] element as the semantic source while custom visuals remain [code]aria-hidden[/code].',
       ],
       title: 'Accessibility Notes',
     },
     {
       items: [
         'Use one curated Loading docs entry that shows Loader, Progress, and CircularProgress side by side.',
-        'Keep controls focused on meaningful loading behavior while passthrough attributes stay native (`aria-*`, `id`, `data-*`).',
+        'Keep controls focused on meaningful loading behavior while passthrough attributes stay native ([code]aria-*[/code], [code]id[/code], [code]data-*[/code]).',
       ],
       title: 'Controls Guidance',
     },

--- a/packages/ui/src/components/primitives/static/typography/typography.docs.ts
+++ b/packages/ui/src/components/primitives/static/typography/typography.docs.ts
@@ -19,8 +19,8 @@ export const typographyDocs = {
   sections: [
     {
       items: [
-        'Use `variant`, `tag`, and text content as the main component API.',
-        'Leave `tag` on the default option to use the selected variant tag mapping.',
+        'Use [code]variant[/code], [code]tag[/code], and text content as the main component API.',
+        'Leave [code]tag[/code] on the default option to use the selected variant tag mapping.',
         'Developers may pass richer content when needed, but it is rendered inside the chosen Typography tag.',
       ],
       title: 'Usage Notes',
@@ -28,14 +28,14 @@ export const typographyDocs = {
     {
       items: [
         'Default tag mappings are intentional and should usually be preserved to keep document structure and semantics predictable.',
-        'Override `tag` deliberately when the surrounding document outline or inline semantics require it.',
-        'Supported passthrough attributes stay narrow: `id`, `title`, `aria-label`, and deliberate `data-*` attributes on the rendered HTML element.',
+        'Override [code]tag[/code] deliberately when the surrounding document outline or inline semantics require it.',
+        'Supported passthrough attributes stay narrow: [code]id[/code], [code]title[/code], [code]aria-label[/code], and deliberate [code]data-*[/code] attributes on the rendered HTML element.',
       ],
       title: 'Accessibility Notes',
     },
     {
       items: [
-        'Storybook controls focus on `children`, `variant`, and `tag` because they cover the meaningful visible API.',
+        'Storybook controls focus on [code]children[/code], [code]variant[/code], and [code]tag[/code] because they cover the meaningful visible API.',
         'Non-visual passthrough attributes are documented here instead of exposed as noisy controls.',
       ],
       title: 'Controls Guidance',


### PR DESCRIPTION
## Summary

Adds a more usable frontend docs playground experience across the React, Vue, and hub Storybooks.

- Adds shared playground snippet generation and rendering so component playgrounds can show copyable React/Vue usage examples beside the live preview.
- Adds a Storybook toolbar control for showing or hiding playground snippets, defaulting snippets to visible and keeping that preference synced across preview iframes.
- Improves composed Storybook behavior in the hub by preserving copied URL args on ref stories and keeping Controls attached to the correct composed preview frame.
- Adds limited BBCode support for shared docs text so inline code and links render explicitly from shared metadata.
- Adds Tabler Icons attribution in icon docs and root third-party notices.
- Aligns the arrow icon path with the rotation behavior used by the other icon assets.
- Documents the current Storybook composition workarounds at the frontend docs level.