### PR TITLE
Feature/frontend docs  dry consistency refactor

### DIFF
--- a/apps/frontend-docs/DOCS_CONSISTENCY_AGENT_NOTES.md
+++ b/apps/frontend-docs/DOCS_CONSISTENCY_AGENT_NOTES.md
@@ -24,6 +24,8 @@ Use this as a fast execution checklist when changing docs under `apps/frontend-d
 
 - Keep React and Vue docs aligned on section order, control intent, and example intent.
 - Keep framework-specific source links present for each framework docs page.
+- Allow framework-native prop naming differences such as React `className` and Vue `class` /
+  `*Class` when they describe the same styling passthrough intent.
 - Keep Storybook config through `createFrontendDocsStorybookConfig<StorybookConfig>(...)`.
 - Register theme addon through `createFrontendDocsAddons(compositionThemeConfig)`.
 - Use `createFrontendDocsPlaygroundParameters(...)` for playground stories so addon-panel visibility stays consistent; override its `addons` option per story when a playground deliberately needs something beyond the default Controls and Accessibility panels.

--- a/apps/frontend-docs/DOCS_CONSISTENCY_README.md
+++ b/apps/frontend-docs/DOCS_CONSISTENCY_README.md
@@ -62,6 +62,10 @@ Use these shared utilities first:
 
 If React and Vue differ, document why in the story or docs description.
 
+Framework prop naming can follow framework conventions without extra explanation. For example,
+React stories may expose `className` while Vue stories expose `class` or component-specific
+`*Class` props for the same styling passthrough intent.
+
 ## Hub Contract Workflow
 
 For `hub/src/stories/*Overview.stories.tsx`, prefer:

--- a/apps/frontend-docs/design-system-react/src/stories/Button.stories.tsx
+++ b/apps/frontend-docs/design-system-react/src/stories/Button.stories.tsx
@@ -23,19 +23,17 @@ import { useEffect, useRef, useState } from 'react';
 
 import { StorybookSourceSnippet } from './StorybookSourceSnippet';
 
-const noIconOption = 'None';
-
-type ButtonIconOption = IconName | typeof noIconOption;
+type ButtonIconOption = IconName | undefined;
 
 type ButtonStoryArgs = {
   children: string;
   disabled: boolean;
   isLoading: boolean;
-  leadingIcon: ButtonIconOption;
+  leadingIcon?: ButtonIconOption;
   loadingLabel: string;
   preventLoadingShrink: boolean;
   size: ButtonSize;
-  trailingIcon: ButtonIconOption;
+  trailingIcon?: ButtonIconOption;
   variant: ButtonVariant;
 };
 
@@ -43,15 +41,11 @@ const defaultButtonArgs: ButtonStoryArgs = {
   children: 'Primary action',
   disabled: false,
   isLoading: false,
-  leadingIcon: noIconOption,
   loadingLabel: '',
   preventLoadingShrink: false,
   size: 'medium',
-  trailingIcon: noIconOption,
   variant: 'primary',
 };
-
-const iconOptions = [noIconOption, ...supportedIconNames] as const;
 
 const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
   children: {
@@ -79,7 +73,7 @@ const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
   leadingIcon: {
     control: 'select',
     description: buttonDocs.argTypeDescriptions.leadingIcon,
-    options: iconOptions,
+    options: supportedIconNames,
     table: {
       category: 'Component API',
     },
@@ -109,7 +103,7 @@ const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
   trailingIcon: {
     control: 'select',
     description: buttonDocs.argTypeDescriptions.trailingIcon,
-    options: iconOptions,
+    options: supportedIconNames,
     table: {
       category: 'Component API',
     },
@@ -152,11 +146,7 @@ export default meta;
 type Story = StoryObj<ButtonStoryArgs>;
 
 function normalizeIcon(icon: ButtonIconOption): IconName | undefined {
-  if (icon === noIconOption) {
-    return undefined;
-  }
-
-  if (supportedIconNames.includes(icon)) {
+  if (icon !== undefined && supportedIconNames.includes(icon)) {
     return icon;
   }
 
@@ -171,9 +161,9 @@ function normalizeButtonArgs(args: ButtonStoryArgs): ButtonStoryArgs {
 
   return {
     ...args,
-    leadingIcon: normalizeIcon(args.leadingIcon) ?? noIconOption,
+    leadingIcon: normalizeIcon(args.leadingIcon),
     size,
-    trailingIcon: normalizeIcon(args.trailingIcon) ?? noIconOption,
+    trailingIcon: normalizeIcon(args.trailingIcon),
     variant,
   };
 }

--- a/apps/frontend-docs/design-system-react/src/stories/Link.docs.mdx
+++ b/apps/frontend-docs/design-system-react/src/stories/Link.docs.mdx
@@ -35,8 +35,7 @@ import { linkVariants } from '@hoite-dev/ui';
     Stories.States,
     {
       code: nextRouterLinkDocsSource,
-      description:
-        'Framework-managed links can keep their routing behavior while sharing the same visual styling as Hoite Dev <Link/> by importing the styles from @hoite-dev/ui.',
+      description: linkDocs.storyDescriptions.routerStyling,
       language: 'tsx',
       title: 'Next.js router link styling',
     },

--- a/apps/frontend-docs/design-system-vue/src/stories/Button.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Button.stories.ts
@@ -1,7 +1,5 @@
 import {
-  copyFrontendDocsSnippetToClipboard,
   createFrontendDocsComponentSnippet,
-  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
   createVueStoryPreview,
   createVueStorySourcePanel,
@@ -20,20 +18,19 @@ import {
 import { Button } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
 import { computed, defineComponent, onBeforeUnmount, ref } from 'vue';
+import { createVueSnippetCopyState } from './vueSnippetCopyState';
 
-const noIconOption = 'None';
-
-type ButtonIconOption = IconName | typeof noIconOption;
+type ButtonIconOption = IconName | undefined;
 
 type ButtonStoryArgs = {
   children: string;
   disabled: boolean;
   isLoading: boolean;
-  leadingIcon: ButtonIconOption;
+  leadingIcon?: ButtonIconOption;
   loadingLabel: string;
   preventLoadingShrink: boolean;
   size: ButtonSize;
-  trailingIcon: ButtonIconOption;
+  trailingIcon?: ButtonIconOption;
   variant: ButtonVariant;
 };
 
@@ -41,15 +38,11 @@ const defaultButtonArgs: ButtonStoryArgs = {
   children: 'Primary action',
   disabled: false,
   isLoading: false,
-  leadingIcon: noIconOption,
   loadingLabel: '',
   preventLoadingShrink: false,
   size: 'medium',
-  trailingIcon: noIconOption,
   variant: 'primary',
 };
-
-const iconOptions = [noIconOption, ...supportedIconNames] as const;
 
 const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
   children: {
@@ -77,7 +70,7 @@ const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
   leadingIcon: {
     control: 'select',
     description: buttonDocs.argTypeDescriptions.leadingIcon,
-    options: iconOptions,
+    options: supportedIconNames,
     table: {
       category: 'Component API',
     },
@@ -107,7 +100,7 @@ const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
   trailingIcon: {
     control: 'select',
     description: buttonDocs.argTypeDescriptions.trailingIcon,
-    options: iconOptions,
+    options: supportedIconNames,
     table: {
       category: 'Component API',
     },
@@ -123,11 +116,7 @@ const storyArgTypes: Partial<ArgTypes<ButtonStoryArgs>> = {
 };
 
 function normalizeIcon(icon: ButtonIconOption): IconName | undefined {
-  if (icon === noIconOption) {
-    return undefined;
-  }
-
-  if (supportedIconNames.includes(icon)) {
+  if (icon !== undefined && supportedIconNames.includes(icon)) {
     return icon;
   }
 
@@ -142,9 +131,9 @@ function normalizeButtonArgs(args: ButtonStoryArgs): ButtonStoryArgs {
 
   return {
     ...args,
-    leadingIcon: normalizeIcon(args.leadingIcon) ?? noIconOption,
+    leadingIcon: normalizeIcon(args.leadingIcon),
     size,
-    trailingIcon: normalizeIcon(args.trailingIcon) ?? noIconOption,
+    trailingIcon: normalizeIcon(args.trailingIcon),
     variant,
   };
 }
@@ -165,7 +154,6 @@ const ButtonPlaygroundPreview = defineComponent({
       type: Boolean,
     },
     leadingIcon: {
-      required: true,
       type: String as () => ButtonIconOption,
     },
     loadingLabel: {
@@ -181,7 +169,6 @@ const ButtonPlaygroundPreview = defineComponent({
       type: String as () => ButtonSize,
     },
     trailingIcon: {
-      required: true,
       type: String as () => ButtonIconOption,
     },
     variant: {
@@ -248,16 +235,7 @@ const ButtonPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const copyButtonLabel = ref('Copy code');
-    const copySnippet = async () => {
-      copyButtonLabel.value = 'Copying';
-      copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
-        ? 'Copied'
-        : 'Copy error';
-    };
-    const highlightedSnippet = computed(() =>
-      createFrontendDocsHighlightedSnippetHtml(snippet.value),
-    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       buttonArgs,

--- a/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Icon.stories.ts
@@ -1,7 +1,5 @@
 import {
-  copyFrontendDocsSnippetToClipboard,
   createFrontendDocsComponentSnippet,
-  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
   createVueStoryPreview,
   createVueStorySourcePanel,
@@ -21,7 +19,8 @@ import {
 } from '@hoite-dev/ui';
 import { Icon } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent } from 'vue';
+import { createVueSnippetCopyState } from './vueSnippetCopyState';
 
 type IconStoryArgs = {
   name: IconName;
@@ -156,16 +155,7 @@ const IconPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const copyButtonLabel = ref('Copy code');
-    const copySnippet = async () => {
-      copyButtonLabel.value = 'Copying';
-      copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
-        ? 'Copied'
-        : 'Copy error';
-    };
-    const highlightedSnippet = computed(() =>
-      createFrontendDocsHighlightedSnippetHtml(snippet.value),
-    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       copyButtonLabel,

--- a/apps/frontend-docs/design-system-vue/src/stories/IconButton.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/IconButton.stories.ts
@@ -1,7 +1,5 @@
 import {
-  copyFrontendDocsSnippetToClipboard,
   createFrontendDocsComponentSnippet,
-  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
   createVueStoryPreview,
   createVueStorySourcePanel,
@@ -20,6 +18,7 @@ import {
 import { IconButton } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
 import { computed, defineComponent, onBeforeUnmount, ref } from 'vue';
+import { createVueSnippetCopyState } from './vueSnippetCopyState';
 
 type IconButtonStoryArgs = {
   'aria-label': string;
@@ -179,16 +178,7 @@ const IconButtonPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const copyButtonLabel = ref('Copy code');
-    const copySnippet = async () => {
-      copyButtonLabel.value = 'Copying';
-      copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
-        ? 'Copied'
-        : 'Copy error';
-    };
-    const highlightedSnippet = computed(() =>
-      createFrontendDocsHighlightedSnippetHtml(snippet.value),
-    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       copyButtonLabel,

--- a/apps/frontend-docs/design-system-vue/src/stories/Link.docs.mdx
+++ b/apps/frontend-docs/design-system-vue/src/stories/Link.docs.mdx
@@ -38,8 +38,7 @@ import { linkVariants } from '@hoite-dev/ui';
     Stories.States,
     {
       code: nuxtRouterLinkDocsSource,
-      description:
-        'Framework-managed links can keep their routing behavior while sharing the same visual styling as Hoite Dev <Link/> by importing the styles from @hoite-dev/ui.',
+      description: linkDocs.storyDescriptions.routerStyling,
       language: 'html',
       title: 'Nuxt router link styling',
     },

--- a/apps/frontend-docs/design-system-vue/src/stories/Link.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Link.stories.ts
@@ -1,7 +1,5 @@
 import {
-  copyFrontendDocsSnippetToClipboard,
   createFrontendDocsComponentSnippet,
-  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
   createVueStoryPreview,
   createVueStorySourcePanel,
@@ -20,7 +18,8 @@ import {
 } from '@hoite-dev/ui';
 import { Link } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { computed, defineComponent, type PropType, ref } from 'vue';
+import { computed, defineComponent, type PropType } from 'vue';
+import { createVueSnippetCopyState } from './vueSnippetCopyState';
 
 const linkPlaygroundControlNames = ['children', 'href', 'appearance', 'target', 'rel'] as const;
 
@@ -169,16 +168,7 @@ const LinkPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const copyButtonLabel = ref('Copy code');
-    const copySnippet = async () => {
-      copyButtonLabel.value = 'Copying';
-      copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
-        ? 'Copied'
-        : 'Copy error';
-    };
-    const highlightedSnippet = computed(() =>
-      createFrontendDocsHighlightedSnippetHtml(snippet.value),
-    );
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       copyButtonLabel,

--- a/apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Loading.stories.ts
@@ -1,7 +1,5 @@
 import {
-  copyFrontendDocsSnippetToClipboard,
   createFrontendDocsComponentSnippet,
-  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
   createVueStoryPreview,
   createVueStorySourcePanel,
@@ -18,7 +16,8 @@ import {
 } from '@hoite-dev/ui';
 import { CircularProgress, Loader, Progress } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { type ComputedRef, computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent } from 'vue';
+import { createVueSnippetCopyState } from './vueSnippetCopyState';
 
 type CircularValueDisplay = 'fraction' | 'percent';
 
@@ -36,25 +35,6 @@ type LoadingStoryArgs = {
   value: number;
   valueDisplay: CircularValueDisplay;
 };
-
-function createSnippetCopyState(snippet: ComputedRef<string>) {
-  const copyButtonLabel = ref('Copy code');
-  const highlightedSnippet = computed(() =>
-    createFrontendDocsHighlightedSnippetHtml(snippet.value),
-  );
-  const copySnippet = async () => {
-    copyButtonLabel.value = 'Copying';
-    copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
-      ? 'Copied'
-      : 'Copy error';
-  };
-
-  return {
-    copyButtonLabel,
-    copySnippet,
-    highlightedSnippet,
-  };
-}
 
 const storyArgTypes: Partial<ArgTypes<LoadingStoryArgs>> = {
   size: {
@@ -192,7 +172,7 @@ const LoaderPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const { copyButtonLabel, copySnippet, highlightedSnippet } = createSnippetCopyState(snippet);
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       copyButtonLabel,
@@ -309,7 +289,7 @@ const ProgressPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const { copyButtonLabel, copySnippet, highlightedSnippet } = createSnippetCopyState(snippet);
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       copyButtonLabel,
@@ -471,7 +451,7 @@ const CircularProgressPlaygroundPreview = defineComponent({
         ],
       }),
     );
-    const { copyButtonLabel, copySnippet, highlightedSnippet } = createSnippetCopyState(snippet);
+    const { copyButtonLabel, copySnippet, highlightedSnippet } = createVueSnippetCopyState(snippet);
 
     return {
       copyButtonLabel,

--- a/apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/Typography.stories.ts
@@ -1,7 +1,5 @@
 import {
-  copyFrontendDocsSnippetToClipboard,
   createFrontendDocsComponentSnippet,
-  createFrontendDocsHighlightedSnippetHtml,
   createFrontendDocsPlaygroundParameters,
   createVueStoryPreview,
   createVueStorySourcePanel,
@@ -17,7 +15,8 @@ import {
 } from '@hoite-dev/ui';
 import { Typography } from '@hoite-dev/ui-vue';
 import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3-vite';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
+import { createVueSnippetCopyState } from './vueSnippetCopyState';
 
 const defaultTagOption = 'Default variant tag';
 const variantKeys = Object.keys(typographyVariantConfig) as TypographyVariant[];
@@ -113,16 +112,8 @@ export const Playground: Story = {
           ],
         }),
       );
-      const copyButtonLabel = ref('Copy code');
-      const copySnippet = async () => {
-        copyButtonLabel.value = 'Copying';
-        copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
-          ? 'Copied'
-          : 'Copy error';
-      };
-      const highlightedSnippet = computed(() =>
-        createFrontendDocsHighlightedSnippetHtml(snippet.value),
-      );
+      const { copyButtonLabel, copySnippet, highlightedSnippet } =
+        createVueSnippetCopyState(snippet);
 
       return {
         args,

--- a/apps/frontend-docs/design-system-vue/src/stories/vueSnippetCopyState.ts
+++ b/apps/frontend-docs/design-system-vue/src/stories/vueSnippetCopyState.ts
@@ -1,0 +1,25 @@
+import {
+  copyFrontendDocsSnippetToClipboard,
+  createFrontendDocsHighlightedSnippetHtml,
+} from '@hoite-dev/frontend-docs-shared/storybook';
+import type { ComputedRef } from 'vue';
+import { computed, ref } from 'vue';
+
+export function createVueSnippetCopyState(snippet: ComputedRef<string>) {
+  const copyButtonLabel = ref('Copy code');
+  const highlightedSnippet = computed(() =>
+    createFrontendDocsHighlightedSnippetHtml(snippet.value),
+  );
+  const copySnippet = async () => {
+    copyButtonLabel.value = 'Copying';
+    copyButtonLabel.value = (await copyFrontendDocsSnippetToClipboard(snippet.value))
+      ? 'Copied'
+      : 'Copy error';
+  };
+
+  return {
+    copyButtonLabel,
+    copySnippet,
+    highlightedSnippet,
+  };
+}

--- a/apps/frontend-docs/hub/src/stories/tokens/TokenPreview.tsx
+++ b/apps/frontend-docs/hub/src/stories/tokens/TokenPreview.tsx
@@ -13,6 +13,10 @@ type TokenPreviewProps = {
 
 const previewBorderColor = 'var(--color-border-strong)';
 
+/**
+ * Shared motion sample used by duration and easing tokens. The static filled
+ * state keeps reduced-motion previews meaningful without running animation.
+ */
 function MotionSweepPreview({
   animation,
   shouldAnimate,
@@ -61,6 +65,10 @@ function renderMotionEasingPreview(cssValue: string, prefersReducedMotion: boole
   );
 }
 
+/**
+ * Uses a fixed twelve-column sample so grid column tokens can show relative
+ * density while staying the same physical size in every table row.
+ */
 function renderLayoutGridColumnsPreview(row: TokenCategoryRow) {
   return (
     <div
@@ -134,6 +142,8 @@ function renderLayoutContainerPreview(row: TokenCategoryRow) {
 }
 
 function renderStrokePreview(row: TokenCategoryRow) {
+  // Focus/highlight stroke tokens need a visible focus-color sample; generic
+  // stroke-width tokens are clearer against the default border color.
   const focusStrokeTokens = ['focus-ring', 'stroke-highlight'];
   const usesFocusStrokeColor = focusStrokeTokens.some((tokenName) =>
     row.cssVarName.includes(tokenName),
@@ -178,6 +188,11 @@ function renderSizePreview(row: TokenCategoryRow) {
   );
 }
 
+/**
+ * TokenPreview is intentionally convention-driven: tokenModel chooses the
+ * preview kind, and this switch translates that metadata into compact table
+ * visuals rather than full component examples.
+ */
 export function TokenPreview({ cssValue, prefersReducedMotion, row }: TokenPreviewProps) {
   switch (row.previewKind) {
     case 'color':

--- a/apps/frontend-docs/hub/src/stories/tokens/TokensDocRenderer.tsx
+++ b/apps/frontend-docs/hub/src/stories/tokens/TokensDocRenderer.tsx
@@ -49,6 +49,8 @@ export function TokensDocRenderer() {
   const colorRows = useMemo(() => {
     return createColorRows();
   }, []);
+  // Build categories once without computed CSS values so we can discover every
+  // variable name, then rebuild after reading resolved values from the page.
   const initialCategories = useMemo(() => {
     return createTokenCategories();
   }, []);

--- a/apps/frontend-docs/hub/src/stories/tokens/tokenFormat.ts
+++ b/apps/frontend-docs/hub/src/stories/tokens/tokenFormat.ts
@@ -8,6 +8,10 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return false;
 }
 
+/**
+ * Prefers the explicit Figma code syntax extension when it exists, then falls
+ * back to a deterministic CSS custom property name derived from the token path.
+ */
 export function resolveCssVar(path: readonly string[], leaf: Record<string, unknown>): string {
   const extensions = leaf.$extensions;
 
@@ -39,6 +43,10 @@ export function resolveCssVar(path: readonly string[], leaf: Record<string, unkn
   return `--${fallback.toLowerCase()}`;
 }
 
+/**
+ * Figma exports color components as normalized 0..1 channel values. Convert
+ * those records into browser-ready rgb/rgba strings for tables and swatches.
+ */
 function formatRgbaFromComponents(value: unknown): string | null {
   if (!isRecord(value)) {
     return null;
@@ -62,6 +70,10 @@ function formatRgbaFromComponents(value: unknown): string | null {
   return `rgb(${red}, ${green}, ${blue})`;
 }
 
+/**
+ * Produces a stable string for arbitrary token values. This keeps unsupported
+ * object shapes visible in docs instead of silently dropping them.
+ */
 export function resolveTokenValue(value: TokenValue): string {
   if (value === null) {
     return 'null';
@@ -135,6 +147,10 @@ export function resolveColorSwatchValue(value: TokenValue): string | null {
   return null;
 }
 
+/**
+ * Extracts the first numeric value from CSS-like strings so scale tokens sort
+ * by magnitude. Composite values intentionally fall back to their first number.
+ */
 export function parseNumber(value: unknown): number | null {
   if (typeof value === 'number') {
     return value;
@@ -144,6 +160,7 @@ export function parseNumber(value: unknown): number | null {
     return null;
   }
 
+  // Match the first signed integer or decimal inside a CSS-like value.
   const match = /-?\d*\.?\d+/.exec(value);
 
   if (!match?.[0]) {
@@ -153,6 +170,10 @@ export function parseNumber(value: unknown): number | null {
   return Number(match[0]);
 }
 
+/**
+ * Normalizes duration tokens to milliseconds for motion previews. Bare numbers
+ * are treated as milliseconds, matching the display convention in the docs.
+ */
 export function parseDurationMs(value: unknown): number | null {
   if (typeof value === 'number') {
     return value;
@@ -163,6 +184,7 @@ export function parseDurationMs(value: unknown): number | null {
   }
 
   const trimmed = value.trim();
+  // Match plain duration values such as "120", "120ms", or "0.2s".
   const unitMatch = /^(-?\d*\.?\d+)\s*(ms|s)?$/i.exec(trimmed);
 
   if (!unitMatch) {

--- a/apps/frontend-docs/hub/src/stories/tokens/tokenModel.ts
+++ b/apps/frontend-docs/hub/src/stories/tokens/tokenModel.ts
@@ -31,6 +31,10 @@ export type TokenPreviewKind =
 
 export type CssValueMap = Record<string, string>;
 
+/**
+ * Normalized leaf token data. The source token tree can nest arbitrary groups,
+ * but the stories render a flat list first and add grouping back later.
+ */
 export type TokenRow = {
   cssVarName: string;
   description: string | null;
@@ -72,6 +76,11 @@ export type TokenCategory = {
 
 const tokenSource = tokens as Record<string, unknown>;
 
+/**
+ * A token leaf is any object that looks like a design token, even if it only
+ * carries metadata. Groups can contain `$` keys too, so callers still recurse
+ * into non-leaf objects instead of treating every record as renderable.
+ */
 function isTokenLeaf(value: unknown): value is Record<string, unknown> {
   if (!isRecord(value)) {
     return false;
@@ -84,6 +93,11 @@ function isTokenLeaf(value: unknown): value is Record<string, unknown> {
   return false;
 }
 
+/**
+ * Converts the nested token export into display rows. `path` tracks the token's
+ * location so CSS variable names, duplicate-name suffixes, and group labels can
+ * be derived from the same source of truth.
+ */
 export function flattenTokenTree(tree: unknown, path: readonly string[] = []): TokenRow[] {
   if (!isRecord(tree)) {
     return [];
@@ -92,6 +106,8 @@ export function flattenTokenTree(tree: unknown, path: readonly string[] = []): T
   if (isTokenLeaf(tree)) {
     const cssVarName = resolveCssVar(path, tree);
     const rawPath = path.join('.');
+    // Drop the top-level category and leaf key from section labels. The middle
+    // path segments are the human-facing groups shown in the token tables.
     const groupPath = path.length > 2 ? path.slice(1, -1).join(' / ') : 'Base';
 
     return [
@@ -110,6 +126,8 @@ export function flattenTokenTree(tree: unknown, path: readonly string[] = []): T
   const leaves: TokenRow[] = [];
 
   for (const [key, child] of Object.entries(tree)) {
+    // Design-token metadata keys describe the current node; they are not child
+    // groups and should not become their own rows.
     if (key.startsWith('$')) {
       continue;
     }
@@ -120,6 +138,10 @@ export function flattenTokenTree(tree: unknown, path: readonly string[] = []): T
   return leaves;
 }
 
+/**
+ * Color tokens are special-cased because the docs combine light and dark rows
+ * into one comparison table instead of using the generic category renderer.
+ */
 function isColorToken(token: TokenRow): boolean {
   if (token.tokenType === 'color') {
     return true;
@@ -132,13 +154,103 @@ function isColorToken(token: TokenRow): boolean {
   return false;
 }
 
+/**
+ * Declarative matcher for the generic token preview components. Color and none
+ * are excluded because they are resolved by explicit guard clauses.
+ */
+type TokenPreviewKindRule = {
+  kind: Exclude<TokenPreviewKind, 'color' | 'none'>;
+  matches: (token: TokenRow) => boolean;
+};
+
+function cssVarIncludes(fragment: string): (token: TokenRow) => boolean {
+  return (token) => token.cssVarName.includes(fragment);
+}
+
+/**
+ * Ordered from most specific to most general. Some names overlap, for example
+ * layout grid tokens may also include size-like values, so first match wins.
+ */
+const tokenPreviewKindRules: readonly TokenPreviewKindRule[] = [
+  {
+    kind: 'motion-duration',
+    matches: cssVarIncludes('--motion-duration'),
+  },
+  {
+    kind: 'motion-easing',
+    matches: cssVarIncludes('--motion-easing'),
+  },
+  {
+    kind: 'layout-grid-columns',
+    matches: (token) =>
+      token.cssVarName.includes('--layout-grid-') && token.cssVarName.includes('-columns'),
+  },
+  {
+    kind: 'layout-gutter',
+    matches: cssVarIncludes('--layout-gutter-'),
+  },
+  {
+    kind: 'layout-container',
+    matches: cssVarIncludes('--layout-container-'),
+  },
+  {
+    kind: 'typography-weight',
+    matches: cssVarIncludes('--typography-weight-'),
+  },
+  {
+    kind: 'typography-size',
+    matches: cssVarIncludes('--typography-size-'),
+  },
+  {
+    kind: 'typography-letter-spacing',
+    matches: cssVarIncludes('--typography-letter-spacing-'),
+  },
+  {
+    kind: 'typography-family',
+    matches: cssVarIncludes('--typography-family-'),
+  },
+  {
+    kind: 'typography-line-height',
+    matches: cssVarIncludes('--typography-line-height-'),
+  },
+  {
+    kind: 'typography-paragraph-spacing',
+    matches: cssVarIncludes('--typography-paragraph-spacing-'),
+  },
+  {
+    kind: 'radius',
+    matches: cssVarIncludes('--radius-'),
+  },
+  {
+    kind: 'stroke',
+    matches: cssVarIncludes('--stroke-'),
+  },
+  {
+    kind: 'spacing',
+    matches: cssVarIncludes('--spacing-'),
+  },
+  {
+    kind: 'size',
+    matches: cssVarIncludes('--size-'),
+  },
+];
+
+/**
+ * Selects the preview renderer for a token row. Category/group exclusions run
+ * before CSS-name matching because a token can technically match a preview kind
+ * while still being clearer without a visual preview in the docs.
+ */
 function resolvePreviewKind(category: string, token: TokenRow): TokenPreviewKind {
   const normalizedGroup = token.groupPath.toLowerCase();
 
+  // Loading tokens include timing and size values, but the loading table reads
+  // better as raw API data than as a set of tiny visual previews.
   if (normalizedGroup.includes('loading')) {
     return 'none';
   }
 
+  // Grid container tokens describe named breakpoint containers, not a single
+  // visual measure, so a generic layout preview would be misleading.
   if (category === 'layout' && normalizedGroup === 'grid-container') {
     return 'none';
   }
@@ -147,69 +259,20 @@ function resolvePreviewKind(category: string, token: TokenRow): TokenPreviewKind
     return 'color';
   }
 
-  if (token.cssVarName.includes('--motion-duration')) {
-    return 'motion-duration';
-  }
+  const matchingRule = tokenPreviewKindRules.find((rule) => rule.matches(token));
 
-  if (token.cssVarName.includes('--motion-easing')) {
-    return 'motion-easing';
-  }
-
-  if (token.cssVarName.includes('--layout-grid-') && token.cssVarName.includes('-columns')) {
-    return 'layout-grid-columns';
-  }
-
-  if (token.cssVarName.includes('--layout-gutter-')) {
-    return 'layout-gutter';
-  }
-
-  if (token.cssVarName.includes('--layout-container-')) {
-    return 'layout-container';
-  }
-
-  if (token.cssVarName.includes('--typography-weight-')) {
-    return 'typography-weight';
-  }
-
-  if (token.cssVarName.includes('--typography-size-')) {
-    return 'typography-size';
-  }
-
-  if (token.cssVarName.includes('--typography-letter-spacing-')) {
-    return 'typography-letter-spacing';
-  }
-
-  if (token.cssVarName.includes('--typography-family-')) {
-    return 'typography-family';
-  }
-
-  if (token.cssVarName.includes('--typography-line-height-')) {
-    return 'typography-line-height';
-  }
-
-  if (token.cssVarName.includes('--typography-paragraph-spacing-')) {
-    return 'typography-paragraph-spacing';
-  }
-
-  if (token.cssVarName.includes('--radius-')) {
-    return 'radius';
-  }
-
-  if (token.cssVarName.includes('--stroke-')) {
-    return 'stroke';
-  }
-
-  if (token.cssVarName.includes('--spacing-')) {
-    return 'spacing';
-  }
-
-  if (token.cssVarName.includes('--size-')) {
-    return 'size';
+  if (matchingRule) {
+    return matchingRule.kind;
   }
 
   return 'none';
 }
 
+/**
+ * When two source tokens resolve to the same CSS variable, keep the CSS var as
+ * the primary label and append the source leaf name so both rows remain
+ * distinguishable in the docs table.
+ */
 function normalizeDuplicateDisplayNames(rows: TokenCategoryRow[]): TokenCategoryRow[] {
   const displayCounts = new Map<string, number>();
 
@@ -233,6 +296,11 @@ function normalizeDuplicateDisplayNames(rows: TokenCategoryRow[]): TokenCategory
   });
 }
 
+/**
+ * Sort numeric scales by their resolved runtime value when possible, then fall
+ * back to CSS variable names for non-numeric tokens such as font families and
+ * easing functions.
+ */
 function sortRows(rows: TokenCategoryRow[], cssValues: CssValueMap): TokenCategoryRow[] {
   return [...rows].sort((leftRow, rightRow) => {
     const left = parseNumber(cssValues[leftRow.cssVarName] || leftRow.value);
@@ -246,6 +314,10 @@ function sortRows(rows: TokenCategoryRow[], cssValues: CssValueMap): TokenCatego
   });
 }
 
+/**
+ * Returns non-color token categories in stable docs order. Primitive tokens are
+ * kept first because other token groups often reference them conceptually.
+ */
 function getNonColorTokenEntries(): [string, unknown][] {
   const entries = Object.entries(tokenSource).filter(([category]) => category !== 'color');
 
@@ -268,6 +340,11 @@ function getNonColorTokenEntries(): [string, unknown][] {
   return entries;
 }
 
+/**
+ * Builds the dedicated color table by joining light and dark theme tokens on
+ * CSS variable name. Theme-only tokens are still included with a null value on
+ * the missing side.
+ */
 export function createColorRows(): ColorTokenRow[] {
   const colorTokens = isRecord(tokenSource.color) ? tokenSource.color : {};
   const lightTokens = flattenTokenTree(colorTokens.light, ['color']);
@@ -328,6 +405,11 @@ export function createColorRows(): ColorTokenRow[] {
   return rows;
 }
 
+/**
+ * Builds the generic token category model consumed by the hub stories:
+ * flatten each source tree, add preview metadata, group by display section, and
+ * sort rows with optional resolved CSS values from the running Storybook frame.
+ */
 export function createTokenCategories(cssValues: CssValueMap = {}): TokenCategory[] {
   return getNonColorTokenEntries().map(([category, tree]) => {
     const flattened = flattenTokenTree(tree, [category]);

--- a/apps/frontend-docs/hub/src/stories/tokens/useComputedCssValues.ts
+++ b/apps/frontend-docs/hub/src/stories/tokens/useComputedCssValues.ts
@@ -3,6 +3,10 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { CssValueMap } from './tokenModel';
 
+/**
+ * Reads resolved CSS custom property values from the docs root when possible.
+ * Falling back to body/document keeps the first render useful before refs attach.
+ */
 function readCssValues(varNames: readonly string[], rootElement: HTMLElement | null): CssValueMap {
   if (typeof window === 'undefined') {
     return {};
@@ -46,6 +50,9 @@ export function useComputedCssValues(
       setValues(readCssValues(varNamesRef.current, element));
     });
 
+    // Storybook and the app shell both express theme changes through attributes
+    // on root/body. Re-read computed vars when those attributes change so the
+    // tables track light/dark and composed theme switches without a page reload.
     observer.observe(root, {
       attributeFilter: ['class', 'data-color-mode', 'data-theme'],
       attributes: true,


### PR DESCRIPTION
# Docs consistency and clarifications

- Button playground controls now treat “no icon” as an unset value instead of a fake `None` icon option.
- Vue docs stories share the snippet copy/highlight state helper instead of repeating it in each story.
- Token docs are easier to follow: preview-kind matching is table-driven, and the parsing/rendering conventions have short comments where the behavior is not obvious.
- Link router examples now pull their description from shared docs copy.
- Frontend-docs consistency notes now call out that React/Vue prop names can follow framework conventions when they describe the same intent.